### PR TITLE
support filter params in list available networks

### DIFF
--- a/client/networks/v1/networks/networks.go
+++ b/client/networks/v1/networks/networks.go
@@ -43,13 +43,33 @@ var availableNetworkListCommand = cli.Command{
 	Name:     "list-available",
 	Usage:    "List available networks",
 	Category: "network",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:     "network-id",
+			Aliases:  []string{"i"},
+			Usage:    "show subnets of the specific network",
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     "network-type",
+			Aliases:  []string{"t"},
+			Usage:    "filter network by network type (vlan or vxlan)",
+			Required: false,
+		},
+	},
 	Action: func(c *cli.Context) error {
 		client, err := client.NewAvailableNetworkClientV1(c)
 		if err != nil {
 			_ = cli.ShowAppHelp(c)
 			return cli.NewExitError(err, 1)
 		}
-		result, err := availablenetworks.ListAll(client)
+
+		opts := availablenetworks.ListOpts{
+			NetworkID: c.String("network-id"),
+			NetworkType: c.String("network-type"),
+		}
+
+		result, err := availablenetworks.ListAll(client, opts)
 		if err != nil {
 			return cli.NewExitError(err, 1)
 		}

--- a/gcore/network/v1/availablenetworks/requests.go
+++ b/gcore/network/v1/availablenetworks/requests.go
@@ -7,7 +7,7 @@ import (
 
 // ListOptsBuilder allows extensions to add additional parameters to the List request.
 type ListOptsBuilder interface {
-	ToInstanceListQuery() (string, error)
+	ToAvailableNetworkListQuery() (string, error)
 }
 
 // ListOpts allows the filtering and sorting of paginated collections through the API.
@@ -16,8 +16,8 @@ type ListOpts struct {
 	NetworkType string            `q:"network_type"`
 }
 
-// ToInstanceListQuery formats a ListOpts into a query string.
-func (opts ListOpts) ToInstanceListQuery() (string, error) {
+// ToAvailableNetworkListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToAvailableNetworkListQuery() (string, error) {
 	q, err := gcorecloud.BuildQueryString(opts)
 	if err != nil {
 		return "", err
@@ -28,7 +28,7 @@ func (opts ListOpts) ToInstanceListQuery() (string, error) {
 func List(c *gcorecloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(c)
 	if opts != nil {
-		query, err := opts.ToInstanceListQuery()
+		query, err := opts.ToAvailableNetworkListQuery()
 		if err != nil {
 			return pagination.Pager{Err: err}
 		}

--- a/gcore/network/v1/availablenetworks/requests.go
+++ b/gcore/network/v1/availablenetworks/requests.go
@@ -5,16 +5,43 @@ import (
 	"github.com/G-Core/gcorelabscloud-go/pagination"
 )
 
-func List(c *gcorecloud.ServiceClient) pagination.Pager {
+// ListOptsBuilder allows extensions to add additional parameters to the List request.
+type ListOptsBuilder interface {
+	ToInstanceListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through the API.
+type ListOpts struct {
+	NetworkID   string            `q:"network_id"`
+	NetworkType string            `q:"network_type"`
+}
+
+// ToInstanceListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToInstanceListQuery() (string, error) {
+	q, err := gcorecloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+func List(c *gcorecloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToInstanceListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
 	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
 		return NetworkPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
 
 // ListAll is a convenience function that returns all networks.
-func ListAll(client *gcorecloud.ServiceClient) ([]Network, error) {
-	pages, err := List(client).AllPages()
+func ListAll(client *gcorecloud.ServiceClient, opts ListOptsBuilder) ([]Network, error) {
+	pages, err := List(client, opts).AllPages()
 	if err != nil {
 		return nil, err
 	}
@@ -25,5 +52,4 @@ func ListAll(client *gcorecloud.ServiceClient) ([]Network, error) {
 	}
 
 	return all, nil
-
 }


### PR DESCRIPTION
Support query params specified in API (https://apidocs.gcorelabs.com/cloud#operation/AvailableNetworkViewSet.get) in list-available networks.