### PR TITLE
GCLOUD2-7583: Add check for available baremetal nodes

### DIFF
--- a/gcore/baremetal/v1/bmcapacity/requests.go
+++ b/gcore/baremetal/v1/bmcapacity/requests.go
@@ -1,0 +1,10 @@
+package bmcapacity
+
+import gcorecloud "github.com/G-Core/gcorelabscloud-go"
+
+// GetAvailableNodes retrieves available baremetal nodes
+func GetAvailableNodes(c *gcorecloud.ServiceClient) (r GetAvailableNodesResult) {
+	url := getAvailableNodesURL(c)
+	_, r.Err = c.Get(url, &r.Body, nil)
+	return
+}

--- a/gcore/baremetal/v1/bmcapacity/results.go
+++ b/gcore/baremetal/v1/bmcapacity/results.go
@@ -1,0 +1,30 @@
+package bmcapacity
+
+import gcorecloud "github.com/G-Core/gcorelabscloud-go"
+
+type availableNodesResult struct {
+	gcorecloud.Result
+}
+
+// Extract is a function that accepts a result and extracts amount of available baremetal nodes
+func (r availableNodesResult) Extract() (*AvailableNodes, error) {
+	var c AvailableNodes
+	err := r.ExtractInto(&c)
+
+	return &c, err
+}
+
+func (r availableNodesResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "")
+}
+
+// AvailableNodes represents available baremetal nodes
+type AvailableNodes struct {
+	Capacity map[string]int `json:"capacity"`
+}
+
+// GetAvailableNodesResult represents the result of a get operation. Call its Extract
+// method to interpret it as a AvailableNodes.
+type GetAvailableNodesResult struct {
+	availableNodesResult
+}

--- a/gcore/baremetal/v1/bmcapacity/testing/doc.go
+++ b/gcore/baremetal/v1/bmcapacity/testing/doc.go
@@ -1,0 +1,1 @@
+package testing

--- a/gcore/baremetal/v1/bmcapacity/testing/fixtures.go
+++ b/gcore/baremetal/v1/bmcapacity/testing/fixtures.go
@@ -1,0 +1,25 @@
+package testing
+
+import "github.com/G-Core/gcorelabscloud-go/gcore/baremetal/v1/bmcapacity"
+
+const (
+	availableNodesResponse = `
+{
+  "capacity": {
+    "bm1-basic-small": 3,
+    "bm1-infrastructure-small": 2,
+    "bm1-infrastructure-medium": 1
+  }
+}
+`
+)
+
+var (
+	availableNodes = bmcapacity.AvailableNodes{
+		Capacity: map[string]int{
+			"bm1-basic-small":           3,
+			"bm1-infrastructure-small":  2,
+			"bm1-infrastructure-medium": 1,
+		},
+	}
+)

--- a/gcore/baremetal/v1/bmcapacity/testing/requests_test.go
+++ b/gcore/baremetal/v1/bmcapacity/testing/requests_test.go
@@ -1,0 +1,40 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/G-Core/gcorelabscloud-go/gcore/baremetal/v1/bmcapacity"
+	th "github.com/G-Core/gcorelabscloud-go/testhelper"
+	fake "github.com/G-Core/gcorelabscloud-go/testhelper/client"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func prepareGetAvailableNodesTestURL() string {
+	return fmt.Sprintf("/v1/bmcapacity/%d/%d", fake.ProjectID, fake.RegionID)
+}
+
+func TestGetCapacity(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc(prepareGetAvailableNodesTestURL(), func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := fmt.Fprint(w, availableNodesResponse)
+		if err != nil {
+			log.Error(err)
+		}
+	})
+
+	client := fake.ServiceTokenClient("bmcapacity", "v1")
+	nodes, err := bmcapacity.GetAvailableNodes(client).Extract()
+
+	require.NoError(t, err)
+	require.Equal(t, availableNodes, *nodes)
+}

--- a/gcore/baremetal/v1/bmcapacity/urls.go
+++ b/gcore/baremetal/v1/bmcapacity/urls.go
@@ -1,0 +1,11 @@
+package bmcapacity
+
+import gcorecloud "github.com/G-Core/gcorelabscloud-go"
+
+func rootURL(c *gcorecloud.ServiceClient) string {
+	return c.ServiceURL()
+}
+
+func getAvailableNodesURL(c *gcorecloud.ServiceClient) string {
+	return rootURL(c)
+}


### PR DESCRIPTION
* Add [check for available baremetal nodes](https://apidocs.gcorelabs.com/cloud#tag/instances/operation/BmCapacityHandler.get)