### PR TITLE
fix reauthenticate on token expiration

### DIFF
--- a/auth_options.go
+++ b/auth_options.go
@@ -56,7 +56,8 @@ func (to TokenOptions) ExtractTokensPair() (string, string, error) {
 // ToMap implements TokenOptionsBuilder
 func (to TokenOptions) ToMap() map[string]interface{} {
 	return map[string]interface{}{
-		"token": to.RefreshToken,
+		"access":  to.AccessToken,
+		"refresh": to.RefreshToken,
 	}
 }
 

--- a/provider_client.go
+++ b/provider_client.go
@@ -495,7 +495,9 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 			if client.ReauthFunc != nil && !state.hasReauthenticated {
 				err = client.Reauthenticate(preReqToken)
 				if err != nil {
-					e := &ErrUnableToReauthenticate{}
+					e := &ErrUnableToReauthenticate{BaseError: BaseError{
+						Info: fmt.Sprint("token expired, unable to reauthenticate. ", err.Error()),
+					} }
 					e.ErrOriginal = respErr
 					return nil, e
 				}


### PR DESCRIPTION
This commit fixes:
1) Original error from token refresh request lost, so no errors related to token refresh returned.
2) Necessary field ("refresh"), containing refresh token missing, for some reason access token passed instead.