### PR TITLE
MKAAS-980 Update DDoS API to match changes from GCLOUD2-9267

### DIFF
--- a/gcore/ddos/v1/ddos/requests.go
+++ b/gcore/ddos/v1/ddos/requests.go
@@ -13,6 +13,7 @@ type CreateProfileOptsBuilder interface {
 
 type CreateProfileOpts struct {
 	ProfileTemplate     int            `json:"profile_template" required:"true" validate:"required"`
+	ProfileTemplateName string         `json:"profile_template_name,omitempty" validate:"omitempty"`
 	BaremetalInstanceID string         `json:"bm_instance_id" required:"true" validate:"required"`
 	IPAddress           string         `json:"ip_address" required:"true" validate:"required,ip4_addr"`
 	Fields              []ProfileField `json:"fields"`
@@ -35,6 +36,7 @@ type UpdateProfileOptsBuilder interface {
 
 type UpdateProfileOpts struct {
 	ProfileTemplate     int            `json:"profile_template" required:"true" validate:"required"`
+	ProfileTemplateName string         `json:"profile_template_name,omitempty" validate:"omitempty"`
 	BaremetalInstanceID string         `json:"bm_instance_id" required:"true" validate:"required"`
 	IPAddress           string         `json:"ip_address" required:"true" validate:"required,ip4_addr"`
 	Fields              []ProfileField `json:"fields" required:"true" validate:"required"`

--- a/gcore/ddos/v1/ddos/results.go
+++ b/gcore/ddos/v1/ddos/results.go
@@ -95,20 +95,21 @@ type TemplateField struct {
 
 // Profile represents active client DDoS protection profile
 type Profile struct {
-	ID              int            `json:"id"`
-	Options         Options        `json:"options"`
-	IPAddress       string         `json:"ip_address"`
-	Site            string         `json:"site"`
-	Fields          []ProfileField `json:"fields"`
-	Protocols       []Protocol     `json:"protocols"`
-	ProfileTemplate int            `json:"profile_template"`
+	ID                         int             `json:"id"`
+	Options                    Options         `json:"options"`
+	IPAddress                  string          `json:"ip_address"`
+	Site                       string          `json:"site,omitempty" validate:"omitempty,max=50"`
+	Fields                     []ProfileField  `json:"fields"`
+	Protocols                  []Protocol      `json:"protocols"`
+	ProfileTemplate            ProfileTemplate `json:"profile_template"`
+	ProfileTemplateDescription string          `json:"profile_template_description,omitempty"`
+	Status                     Status          `json:"status,omitempty"`
 }
 
 // Options represent options of active client DDoS protection profile
 type Options struct {
-	Price  string `json:"price"`
-	BGP    bool   `json:"bgp"`
-	Active bool   `json:"active"`
+	BGP    bool `json:"bgp"`
+	Active bool `json:"active"`
 }
 
 type Protocol struct {
@@ -128,6 +129,12 @@ type ProfileField struct {
 	Required         bool            `json:"required,omitempty"`
 	FieldValue       json.RawMessage `json:"field_value,omitempty" required_without:"Value"`
 	ValidationSchema json.RawMessage `json:"validation_schema,omitempty"`
+}
+
+// Status represents the status of DDoS protection profile
+type Status struct {
+	Status           string `json:"status,omitempty"`
+	ErrorDescription string `json:"error_description,omitempty"`
 }
 
 // ProfileTemplatesPage is the page returned by a pager when traversing over a

--- a/gcore/ddos/v1/ddos/testing/fixtures.go
+++ b/gcore/ddos/v1/ddos/testing/fixtures.go
@@ -41,12 +41,25 @@ const (
   "results": [
     {
       "id": 1,
-      "profile_template": 0,
+      "profile_template": {
+        "id": 1,
+        "name": "test_client_profile_template",
+        "description": "test client profile template",
+        "fields": [
+          {
+            "id": 0,
+            "name": "test_field",
+            "description": "test field",
+            "field_type": "int",
+            "required": true,
+            "default": "string"
+          }
+        ]
+      },
       "ip_address": "123.123.123.1",
       "site": "example.com",
       "options": {
         "bgp": true,
-        "price": "string",
         "active": true
       },
       "fields": [
@@ -151,13 +164,26 @@ var (
 	}
 
 	profile = ddos.Profile{
-		ID:              1,
-		ProfileTemplate: 0,
-		IPAddress:       "123.123.123.1",
+		ID: 1,
+		ProfileTemplate: ddos.ProfileTemplate{
+			ID:          1,
+			Name:        "test_client_profile_template",
+			Description: "test client profile template",
+			Fields: []ddos.TemplateField{
+				{
+					ID:          0,
+					Name:        "test_field",
+					Description: "test field",
+					FieldType:   "int",
+					Required:    true,
+					Default:     defaultString,
+				},
+			},
+		},
+		IPAddress: "123.123.123.1",
 		Options: ddos.Options{
 			Active: true,
 			BGP:    true,
-			Price:  "string",
 		},
 		Site: "example.com",
 		Fields: []ddos.ProfileField{


### PR DESCRIPTION
GCLOUD2-9267 added and removed a few fields, but most importantly contained a backwards-incompatible change of `Profile.ProfileTemplate` from `int` to a nested object.