### PR TITLE
MKAAS-981 Add support for DDoS profiles on load balancers

### DIFF
--- a/gcore/baremetal/v1/bminstances/requests.go
+++ b/gcore/baremetal/v1/bminstances/requests.go
@@ -18,6 +18,7 @@ type ListOpts struct {
 	Name     string            `q:"name"`
 	FlavorID string            `q:"flavor_id"`
 	Metadata map[string]string `q:"metadata_kv" validate:"omitempty"`
+	WithDdos bool              `q:"with_ddos" validate:"omitempty"`
 }
 
 // ToInstanceListQuery formats a ListOpts into a query string.

--- a/gcore/ddos/v1/ddos/requests.go
+++ b/gcore/ddos/v1/ddos/requests.go
@@ -6,6 +6,13 @@ import (
 	"github.com/G-Core/gcorelabscloud-go/pagination"
 )
 
+type ResourceType string
+
+const (
+	ResourceTypeInstance     ResourceType = "instance"
+	ResourceTypeLoadBalancer ResourceType = "loadbalancer"
+)
+
 // CreateProfileOptsBuilder allows extensions to add additional parameters to the Create request.
 type CreateProfileOptsBuilder interface {
 	ToProfileCreateMap() (map[string]interface{}, error)
@@ -14,9 +21,11 @@ type CreateProfileOptsBuilder interface {
 type CreateProfileOpts struct {
 	ProfileTemplate     int            `json:"profile_template" required:"true" validate:"required"`
 	ProfileTemplateName string         `json:"profile_template_name,omitempty" validate:"omitempty"`
-	BaremetalInstanceID string         `json:"bm_instance_id" required:"true" validate:"required"`
+	BaremetalInstanceID string         `json:"bm_instance_id,omitempty" validate:"omitempty,required_without=ResourceID"`
+	ResourceID          string         `json:"resource_id,omitempty" validate:"omitempty,required_without=BaremetalInstanceID"`
+	ResourceType        ResourceType   `json:"resource_type,omitempty" validate:"omitempty,enum"`
 	IPAddress           string         `json:"ip_address" required:"true" validate:"required,ip4_addr"`
-	Fields              []ProfileField `json:"fields"`
+	Fields              []ProfileField `json:"fields" required:"true" validate:"required"`
 }
 
 // ToProfileCreateMap builds a request body from CreateProfileOpts.
@@ -37,7 +46,9 @@ type UpdateProfileOptsBuilder interface {
 type UpdateProfileOpts struct {
 	ProfileTemplate     int            `json:"profile_template" required:"true" validate:"required"`
 	ProfileTemplateName string         `json:"profile_template_name,omitempty" validate:"omitempty"`
-	BaremetalInstanceID string         `json:"bm_instance_id" required:"true" validate:"required"`
+	BaremetalInstanceID string         `json:"bm_instance_id,omitempty" validate:"omitempty,required_without=ResourceID"`
+	ResourceID          string         `json:"resource_id,omitempty" validate:"omitempty,required_without=BaremetalInstanceID"`
+	ResourceType        ResourceType   `json:"resource_type,omitempty" validate:"omitempty,enum"`
 	IPAddress           string         `json:"ip_address" required:"true" validate:"required,ip4_addr"`
 	Fields              []ProfileField `json:"fields" required:"true" validate:"required"`
 }

--- a/gcore/ddos/v1/ddos/testing/fixtures.go
+++ b/gcore/ddos/v1/ddos/testing/fixtures.go
@@ -87,7 +87,8 @@ const (
 
 	createProfileRequest = `
 {
-  "bm_instance_id": "9f310fe7-baa2-47a3-b6a6-63c5d78becc2",
+  "resource_id": "9f310fe7-baa2-47a3-b6a6-63c5d78becc2",
+  "resource_type": "instance",
   "profile_template": 1,
   "ip_address": "123.123.123.1",
   "fields": [
@@ -99,7 +100,7 @@ const (
 }
 `
 
-	updateProfileRequest = `
+	createProfileRequestLegacy = `
 {
   "bm_instance_id": "9f310fe7-baa2-47a3-b6a6-63c5d78becc2",
   "profile_template": 1,
@@ -112,7 +113,34 @@ const (
   ]
 }
 `
+	updateProfileRequest = `
+{
+  "resource_id": "9f310fe7-baa2-47a3-b6a6-63c5d78becc2",
+  "resource_type": "loadbalancer",
+  "profile_template": 1,
+  "ip_address": "123.123.123.1",
+  "fields": [
+    {
+      "value": "string",
+      "base_field": 1
+    }
+  ]
+}
+`
 
+	updateProfileRequestLegacy = `
+{
+  "bm_instance_id": "9f310fe7-baa2-47a3-b6a6-63c5d78becc2",
+  "profile_template": 1,
+  "ip_address": "123.123.123.1",
+  "fields": [
+    {
+      "value": "string",
+      "base_field": 1
+    }
+  ]
+}
+`
 	activateProfileRequest = `
 {
     "active": true,

--- a/gcore/ddos/v1/ddos/testing/options_test.go
+++ b/gcore/ddos/v1/ddos/testing/options_test.go
@@ -10,9 +10,10 @@ import (
 
 func TestCreateProfileOpts(t *testing.T) {
 	options := ddos.CreateProfileOpts{
-		ProfileTemplate:     1,
-		BaremetalInstanceID: "9f310fe7-baa2-47a3-b6a6-63c5d78becc2",
-		IPAddress:           "123.123.123.1",
+		ProfileTemplate: 1,
+		ResourceID:      "9f310fe7-baa2-47a3-b6a6-63c5d78becc2",
+		ResourceType:    ddos.ResourceTypeInstance,
+		IPAddress:       "123.123.123.1",
 		Fields: []ddos.ProfileField{
 			{
 				Value:     "string",
@@ -28,7 +29,48 @@ func TestCreateProfileOpts(t *testing.T) {
 	require.JSONEq(t, createProfileRequest, string(s))
 }
 
+func TestCreateProfileOptsLegacy(t *testing.T) {
+	options := ddos.CreateProfileOpts{
+		ProfileTemplate:     1,
+		BaremetalInstanceID: "9f310fe7-baa2-47a3-b6a6-63c5d78becc2",
+		IPAddress:           "123.123.123.1",
+		Fields: []ddos.ProfileField{
+			{
+				Value:     "string",
+				BaseField: 1,
+			},
+		},
+	}
+
+	mp, err := options.ToProfileCreateMap()
+	require.NoError(t, err)
+	s, err := json.Marshal(mp)
+	require.NoError(t, err)
+	require.JSONEq(t, createProfileRequestLegacy, string(s))
+}
+
 func TestUpdateProfileOpts(t *testing.T) {
+	options := ddos.UpdateProfileOpts{
+		ResourceID:      "9f310fe7-baa2-47a3-b6a6-63c5d78becc2",
+		ResourceType:    ddos.ResourceTypeLoadBalancer,
+		ProfileTemplate: 1,
+		IPAddress:       "123.123.123.1",
+		Fields: []ddos.ProfileField{
+			{
+				Value:     "string",
+				BaseField: 1,
+			},
+		},
+	}
+
+	mp, err := options.ToProfileUpdateMap()
+	require.NoError(t, err)
+	s, err := json.Marshal(mp)
+	require.NoError(t, err)
+	require.JSONEq(t, updateProfileRequest, string(s))
+}
+
+func TestUpdateProfileOptsLegacy(t *testing.T) {
 	options := ddos.UpdateProfileOpts{
 		BaremetalInstanceID: "9f310fe7-baa2-47a3-b6a6-63c5d78becc2",
 		ProfileTemplate:     1,
@@ -45,7 +87,7 @@ func TestUpdateProfileOpts(t *testing.T) {
 	require.NoError(t, err)
 	s, err := json.Marshal(mp)
 	require.NoError(t, err)
-	require.JSONEq(t, updateProfileRequest, string(s))
+	require.JSONEq(t, updateProfileRequestLegacy, string(s))
 }
 
 func TestActivateProfileOpts(t *testing.T) {

--- a/gcore/ddos/v1/ddos/testing/requests_test.go
+++ b/gcore/ddos/v1/ddos/testing/requests_test.go
@@ -173,9 +173,10 @@ func TestCreateProfile(t *testing.T) {
 
 	client := fake.ServiceTokenClient("ddos/profiles", "v1")
 	opts := ddos.CreateProfileOpts{
-		IPAddress:           "123.123.123.1",
-		ProfileTemplate:     1,
-		BaremetalInstanceID: "9f310fe7-baa2-47a3-b6a6-63c5d78becc2",
+		IPAddress:       "123.123.123.1",
+		ProfileTemplate: 1,
+		ResourceID:      "9f310fe7-baa2-47a3-b6a6-63c5d78becc2",
+		ResourceType:    ddos.ResourceTypeInstance,
 		Fields: []ddos.ProfileField{
 			{
 				BaseField: 1,
@@ -232,10 +233,11 @@ func TestUpdateProfile(t *testing.T) {
 	})
 
 	opts := ddos.UpdateProfileOpts{
-		ProfileTemplate:     7,
-		BaremetalInstanceID: "9f310fe7-baa2-47a3-b6a6-63c5d78becc2",
-		IPAddress:           "123.123.123.1",
-		Fields:              make([]ddos.ProfileField, 0),
+		ProfileTemplate: 7,
+		ResourceID:      "9f310fe7-baa2-47a3-b6a6-63c5d78becc2",
+		ResourceType:    ddos.ResourceTypeLoadBalancer,
+		IPAddress:       "123.123.123.1",
+		Fields:          make([]ddos.ProfileField, 0),
 	}
 
 	client := fake.ServiceTokenClient("ddos/profiles", "v1")

--- a/gcore/instance/v1/instances/requests.go
+++ b/gcore/instance/v1/instances/requests.go
@@ -28,6 +28,7 @@ type ListOpts struct {
 	Limit             int               `q:"limit" validate:"omitempty,gt=0"`
 	Offset            int               `q:"offset" validate:"omitempty,gt=0"`
 	Metadata          map[string]string `q:"metadata_kv" validate:"omitempty"`
+	WithDdos          bool              `q:"with_ddos" validate:"omitempty"`
 }
 
 // ToInstanceListQuery formats a ListOpts into a query string.

--- a/gcore/instance/v1/instances/results.go
+++ b/gcore/instance/v1/instances/results.go
@@ -6,6 +6,7 @@ import (
 	"net"
 
 	gcorecloud "github.com/G-Core/gcorelabscloud-go"
+	"github.com/G-Core/gcorelabscloud-go/gcore/ddos/v1/ddos"
 	"github.com/G-Core/gcorelabscloud-go/gcore/flavor/v1/flavors"
 	"github.com/G-Core/gcorelabscloud-go/gcore/instance/v1/types"
 	"github.com/G-Core/gcorelabscloud-go/gcore/task/v1/tasks"
@@ -161,6 +162,7 @@ type Instance struct {
 	RegionID         int                          `json:"region_id"`
 	Region           string                       `json:"region"`
 	AvailabilityZone string                       `json:"availability_zone"`
+	DdosProfile      *ddos.Profile                `json:"ddos_profile"`
 }
 
 // Interface represents a instance port interface.

--- a/gcore/loadbalancer/v1/loadbalancers/requests.go
+++ b/gcore/loadbalancer/v1/loadbalancers/requests.go
@@ -33,6 +33,7 @@ type ListOpts struct {
 	AssignedFloating bool              `q:"assigned_floating" validate:"omitempty"`
 	MetadataK        string            `q:"metadata_k" validate:"omitempty"`
 	MetadataKV       map[string]string `q:"metadata_kv" validate:"omitempty"`
+	WithDdos         bool              `q:"with_ddos" validate:"omitempty"`
 }
 
 // ToLoadBalancerListQuery formats a ListOpts into a query string.

--- a/gcore/loadbalancer/v1/loadbalancers/results.go
+++ b/gcore/loadbalancer/v1/loadbalancers/results.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	gcorecloud "github.com/G-Core/gcorelabscloud-go"
+	"github.com/G-Core/gcorelabscloud-go/gcore/ddos/v1/ddos"
 	"github.com/G-Core/gcorelabscloud-go/gcore/loadbalancer/v1/lbflavors"
 	"github.com/G-Core/gcorelabscloud-go/gcore/loadbalancer/v1/types"
 	"github.com/G-Core/gcorelabscloud-go/gcore/task/v1/tasks"
@@ -89,6 +90,7 @@ type LoadBalancer struct {
 	Tags               []string                 `json:"tags"`
 	Flavor             lbflavors.Flavor         `json:"flavor"`
 	Metadata           []metadata.Metadata      `json:"metadata"`
+	DdosProfile        *ddos.Profile            `json:"ddos_profile"`
 }
 
 func (lb LoadBalancer) IsDeleted() bool {


### PR DESCRIPTION
Adds:

- `ResourceID` and `ResourceType` fields to `CreateProfileOpts` enabling DDoS profile support for load balancers and VM instances.
- `WithDdos` option to listing load balancers, instances and bminstances.
- Optional `DdosProfile` field to load balancers and instances.