### PR TITLE
Add "Protocol" to lbpool update opts

### DIFF
--- a/gcore/loadbalancer/v1/lbpools/requests.go
+++ b/gcore/loadbalancer/v1/lbpools/requests.go
@@ -160,6 +160,7 @@ type UpdateOptsBuilder interface {
 type UpdateOpts struct {
 	Name                 string                        `json:"name,omitempty"`
 	Members              []CreatePoolMemberOpts        `json:"members,omitempty"`
+	Protocol             types.ProtocolType            `json:"protocol,omitempty"`
 	LBPoolAlgorithm      types.LoadBalancerAlgorithm   `json:"lb_algorithm,omitempty"`
 	HealthMonitor        *CreateHealthMonitorOpts      `json:"healthmonitor,omitempty"`
 	SessionPersistence   *CreateSessionPersistenceOpts `json:"session_persistence"`


### PR DESCRIPTION
Patch load balancer pool now supports protocol change. 

New field has been added to lbpools.UpdateOpts to support this API change with gcorelabscloud-go client. 