### PR TITLE
GCLOUD2-12829 Remove validation from VolumeType Unmarshal

### DIFF
--- a/gcore/volume/v1/volumes/types.go
+++ b/gcore/volume/v1/volumes/types.go
@@ -229,12 +229,7 @@ func (vt *VolumeType) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}
-	v := VolumeType(s)
-	err := v.IsValid()
-	if err != nil {
-		return err
-	}
-	*vt = v
+	*vt = VolumeType(s)
 	return nil
 }
 


### PR DESCRIPTION
The validation in custom VolumeType.Unmarshal prevents decoding empty / null values.