### PR TITLE
MKAAS-1129 Add missing additional_vips field in load balancers

### DIFF
--- a/gcore/loadbalancer/v1/loadbalancers/results.go
+++ b/gcore/loadbalancer/v1/loadbalancers/results.go
@@ -93,6 +93,7 @@ type LoadBalancer struct {
 	DdosProfile        *ddos.Profile            `json:"ddos_profile"`
 	VrrpIPs            []NetworkPortFixedIP     `json:"vrrp_ips"`
 	VipIPFamilyType    types.IPFamilyType       `json:"vip_ip_family"`
+	AdditionalVips     []NetworkPortFixedIP     `json:"additional_vips"`
 	Logging            *Logging                 `json:"logging"`
 }
 

--- a/gcore/loadbalancer/v1/loadbalancers/testing/fixtures.go
+++ b/gcore/loadbalancer/v1/loadbalancers/testing/fixtures.go
@@ -58,7 +58,13 @@ var ListResponse = fmt.Sprintf(`
       "region_id": 1,
  	    "metadata": [%s],
       "vrrp_ips": [%s],
-      "vip_ip_family": "dual"
+      "vip_ip_family": "dual",
+      "additional_vips": [
+        {
+          "ip_address": "aa:bb:cc:dd::29d",
+          "subnet_id": "abd99b68-e139-4715-b8c2-37ca324285b8"
+        }
+      ]
     }
   ]
 }
@@ -97,7 +103,13 @@ var GetResponse = fmt.Sprintf(`
   "region_id": 1,
   "metadata": [%s],
   "vrrp_ips": [%s],
-  "vip_ip_family": "dual"
+  "vip_ip_family": "dual",
+  "additional_vips": [
+    {
+      "ip_address": "aa:bb:cc:dd::29d",
+      "subnet_id": "abd99b68-e139-4715-b8c2-37ca324285b8"
+    }
+  ]
 }
 `, testing.MetadataResponse, VrrpIPsResponse)
 
@@ -150,7 +162,7 @@ const CreateRequest = `
 const UpdateRequest = `
 {
 	"name": "lbname"
-}	
+}
 `
 
 const CreateResponse = `
@@ -201,7 +213,10 @@ var (
 			{IpAddress: net.ParseIP("10.94.76.179"), SubnetID: "db5ebada-a86a-4702-8a19-00b23a1acb05"},
 			{IpAddress: net.ParseIP("aa:bb:cc:dd::2b5"), SubnetID: "abd99b68-e139-4715-b8c2-37ca324285b8"},
 		},
-    VipIPFamilyType: types.DualStackIPFamilyType,
+		VipIPFamilyType: types.DualStackIPFamilyType,
+		AdditionalVips: []loadbalancers.NetworkPortFixedIP{
+			{IpAddress: net.ParseIP("aa:bb:cc:dd::29d"), SubnetID: "abd99b68-e139-4715-b8c2-37ca324285b8"},
+		},
 	}
 	Tasks1 = tasks.TaskResults{
 		Tasks: []tasks.TaskID{"50f53a35-42ed-40c4-82b2-5a37fb3e00bc"},


### PR DESCRIPTION
**Changelog:**

- Add missing `additional_vips` field to load balancer struct.

The field was added to the API in GCLOUD2-12568, but it looks like we missed it in GCLOUD2-12605 PRs.