### PR TITLE
MKAAS-1268 Add missing update pool opts

### DIFF
--- a/client/k8s/v2/k8s/pools.go
+++ b/client/k8s/v2/k8s/pools.go
@@ -215,8 +215,9 @@ var poolUpdateSubCommand = cli.Command{
 			_ = cli.ShowAppHelp(c)
 			return cli.NewExitError(err, 1)
 		}
+		autoHealingEnabled := c.Bool("auto-healing-enabled")
 		opts := pools.UpdateOpts{
-			AutoHealingEnabled: c.Bool("auto-healing-enabled"),
+			AutoHealingEnabled: &autoHealingEnabled,
 			MinNodeCount:       c.Int("min-node-count"),
 			MaxNodeCount:       c.Int("max-node-count"),
 		}

--- a/gcore/k8s/v2/pools/requests.go
+++ b/gcore/k8s/v2/pools/requests.go
@@ -26,6 +26,8 @@ type CreateOpts struct {
 	AutoHealingEnabled bool                           `json:"auto_healing_enabled,omitempty"`
 	ServerGroupPolicy  servergroups.ServerGroupPolicy `json:"servergroup_policy" validate:"omitempty,enum"`
 	IsPublicIPv4       bool                           `json:"is_public_ipv4,omitempty"`
+	Labels             map[string]string              `json:"labels,omitempty"`
+	Taints             map[string]string              `json:"taints,omitempty"`
 }
 
 // Validate CreateOpts
@@ -49,9 +51,11 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts represents options used to update a pool.
 type UpdateOpts struct {
-	AutoHealingEnabled bool `json:"auto_healing_enabled,omitempty"`
-	MinNodeCount       int  `json:"min_node_count,omitempty" validate:"omitempty,gt=0,lte=20,ltefield=MaxNodeCount"`
-	MaxNodeCount       int  `json:"max_node_count,omitempty" validate:"omitempty,gt=0,lte=20,gtefield=MinNodeCount"`
+	AutoHealingEnabled *bool              `json:"auto_healing_enabled,omitempty"`
+	MinNodeCount       int                `json:"min_node_count,omitempty" validate:"omitempty,gt=0,lte=20,ltefield=MaxNodeCount"`
+	MaxNodeCount       int                `json:"max_node_count,omitempty" validate:"omitempty,gt=0,lte=20,gtefield=MinNodeCount"`
+	Labels             *map[string]string `json:"labels,omitempty"`
+	Taints             *map[string]string `json:"taints,omitempty"`
 }
 
 // Validate UpdateOpts

--- a/gcore/k8s/v2/pools/results.go
+++ b/gcore/k8s/v2/pools/results.go
@@ -54,6 +54,8 @@ type ClusterPool struct {
 	ServerGroupID      string             `json:"servergroup_id"`
 	ServerGroupName    string             `json:"servergroup_name"`
 	ServerGroupPolicy  string             `json:"servergroup_policy"`
+	Labels             map[string]string  `json:"labels,omitempty"`
+	Taints             map[string]string  `json:"taints,omitempty"`
 }
 
 // ClusterPoolPage is the page returned by a pager when traversing over a

--- a/gcore/k8s/v2/pools/testing/fixtures.go
+++ b/gcore/k8s/v2/pools/testing/fixtures.go
@@ -29,7 +29,10 @@ const ListResponse = `
       "status": "Running",
       "node_count": 1,
       "boot_volume_type": "ssd_hiiops",
-      "auto_healing_enabled": false
+      "auto_healing_enabled": false,
+      "servergroup_id": "f3446423-0a82-475a-a1bd-31ce788ace9e",
+      "servergroup_name": "affinity",
+      "servergroup_policy": "affinity"
     }
   ]
 }
@@ -75,17 +78,83 @@ const GetResponse = `
 }
 `
 
-const UpdateRequest = `
+const UpdateRequest1 = `
 {
-  "min_mode_count": 1,
-  "max_mode_count": 3,
+  "auto_healing_enabled": true
 }
 `
 
-const UpdateResponse = `
+const UpdateRequest2 = `
+{
+  "auto_healing_enabled": false
+}
+`
+
+const UpdateRequest3 = `
+{
+  "min_node_count": 2,
+  "max_node_count": 3
+}
+`
+
+const UpdateRequest4 = `
+{
+  "labels": {"foo": "bar"},
+  "taints": {"qux": "wat:NoSchedule"}
+}
+`
+
+const UpdateRequest5 = `
+{
+  "labels": {},
+  "taints": {}
+}
+`
+
+const UpdateResponse1 = `
 {
   "flavor_id": "g0-standard-2-4",
   "min_node_count": 1,
+  "name": "pool-1",
+  "created_at": "2023-08-28T09:40:39Z",
+  "id": "f3446423-0a82-475a-a1bd-31ce788ace9e",
+  "boot_volume_size": 50,
+  "max_node_count": 1,
+  "is_public_ipv4": false,
+  "status": "Running",
+  "node_count": 1,
+  "boot_volume_type": "ssd_hiiops",
+  "auto_healing_enabled": true,
+  "servergroup_policy": "affinity",
+  "servergroup_id": "f3446423-0a82-475a-a1bd-31ce788ace9e",
+  "servergroup_name": "affinity"
+}
+`
+
+const UpdateResponse2 = `
+{
+  "flavor_id": "g0-standard-2-4",
+  "min_node_count": 1,
+  "name": "pool-1",
+  "created_at": "2023-08-28T09:40:39Z",
+  "id": "f3446423-0a82-475a-a1bd-31ce788ace9e",
+  "boot_volume_size": 50,
+  "max_node_count": 1,
+  "is_public_ipv4": false,
+  "status": "Running",
+  "node_count": 1,
+  "boot_volume_type": "ssd_hiiops",
+  "auto_healing_enabled": false,
+  "servergroup_policy": "affinity",
+  "servergroup_id": "f3446423-0a82-475a-a1bd-31ce788ace9e",
+  "servergroup_name": "affinity"
+}
+`
+
+const UpdateResponse3 = `
+{
+  "flavor_id": "g0-standard-2-4",
+  "min_node_count": 2,
   "name": "pool-1",
   "created_at": "2023-08-28T09:40:39Z",
   "id": "f3446423-0a82-475a-a1bd-31ce788ace9e",
@@ -99,6 +168,50 @@ const UpdateResponse = `
   "servergroup_policy": "affinity",
   "servergroup_id": "f3446423-0a82-475a-a1bd-31ce788ace9e",
   "servergroup_name": "affinity"
+}
+`
+
+const UpdateResponse4 = `
+{
+  "flavor_id": "g0-standard-2-4",
+  "min_node_count": 1,
+  "name": "pool-1",
+  "created_at": "2023-08-28T09:40:39Z",
+  "id": "f3446423-0a82-475a-a1bd-31ce788ace9e",
+  "boot_volume_size": 50,
+  "max_node_count": 1,
+  "is_public_ipv4": false,
+  "status": "Running",
+  "node_count": 1,
+  "boot_volume_type": "ssd_hiiops",
+  "auto_healing_enabled": false,
+  "servergroup_policy": "affinity",
+  "servergroup_id": "f3446423-0a82-475a-a1bd-31ce788ace9e",
+  "servergroup_name": "affinity",
+  "labels": {"foo": "bar"},
+  "taints": {"qux": "wat:NoSchedule"}
+}
+`
+
+const UpdateResponse5 = `
+{
+  "flavor_id": "g0-standard-2-4",
+  "min_node_count": 1,
+  "name": "pool-1",
+  "created_at": "2023-08-28T09:40:39Z",
+  "id": "f3446423-0a82-475a-a1bd-31ce788ace9e",
+  "boot_volume_size": 50,
+  "max_node_count": 1,
+  "is_public_ipv4": false,
+  "status": "Running",
+  "node_count": 1,
+  "boot_volume_type": "ssd_hiiops",
+  "auto_healing_enabled": false,
+  "servergroup_policy": "affinity",
+  "servergroup_id": "f3446423-0a82-475a-a1bd-31ce788ace9e",
+  "servergroup_name": "affinity",
+  "labels": {},
+  "taints": {}
 }
 `
 


### PR DESCRIPTION
**Changelog:**

- Add labels/taints support to cluster pool APIs.
  - Update uses ptrs to support clearing labels/taints with empty maps ([playground](https://go.dev/play/p/s1PMiyZUW7K)).
- Make `AutoHealingEnabled` a ptr to support sending `false` value.