### PR TITLE
MKAAS-1283 Add support for advanced k8s settings

### DIFF
--- a/gcore/k8s/v2/clusters/results.go
+++ b/gcore/k8s/v2/clusters/results.go
@@ -55,14 +55,31 @@ type GetResult struct {
 	commonResult
 }
 
+type Authentication struct {
+	OIDC *OIDC `json:"oidc,omitempty"`
+}
+
+type OIDC struct {
+	ClientID       string            `json:"client_id,omitempty"`
+	GroupsClaim    string            `json:"groups_claim,omitempty"`
+	GroupsPrefix   string            `json:"groups_prefix,omitempty"`
+	IssuerURL      string            `json:"issuer_url,omitempty"`
+	RequiredClaims map[string]string `json:"required_claims,omitempty"`
+	SigningAlgs    []string          `json:"signing_algs,omitempty"`
+	UsernameClaim  string            `json:"username_claim,omitempty"`
+	UsernamePrefix string            `json:"username_prefix,omitempty"`
+}
+
 type Cilium struct {
 	MaskSize                 int             `json:"mask_size,omitempty"`
 	MaskSizeV6               int             `json:"mask_size_v6,omitempty"`
 	Tunnel                   TunnelType      `json:"tunnel,omitempty"`
 	Encryption               bool            `json:"encryption"`
-	LoadBalancerMode         LBModeType      `json:"lb_mode,omitemtpy"`
+	LoadBalancerMode         LBModeType      `json:"lb_mode,omitempty"`
 	LoadBalancerAcceleration bool            `json:"lb_acceleration"`
 	RoutingMode              RoutingModeType `json:"routing_mode,omitempty"`
+	HubbleRelay              bool            `json:"hubble_relay"`
+	HubbleUI                 bool            `json:"hubble_ui"`
 }
 
 type CNI struct {
@@ -81,6 +98,8 @@ type Cluster struct {
 	Pools            []pools.ClusterPool `json:"pools"`
 	Version          string              `json:"version"`
 	IsPublic         bool                `json:"is_public"`
+	Authentication   *Authentication     `json:"authentication,omitempty"`
+	AutoscalerConfig map[string]string   `json:"autoscaler_config,omitempty"`
 	CNI              *CNI                `json:"cni,omitempty"`
 	FixedNetwork     string              `json:"fixed_network"`
 	FixedSubnet      string              `json:"fixed_subnet"`

--- a/gcore/k8s/v2/clusters/urls.go
+++ b/gcore/k8s/v2/clusters/urls.go
@@ -30,6 +30,10 @@ func getURL(c *gcorecloud.ServiceClient, clusterName string) string {
 	return resourceURL(c, clusterName)
 }
 
+func updateURL(c *gcorecloud.ServiceClient, clusterName string) string {
+	return resourceURL(c, clusterName)
+}
+
 func deleteURL(c *gcorecloud.ServiceClient, clusterName string) string {
 	return resourceURL(c, clusterName)
 }

--- a/gcore/k8s/v2/pools/requests.go
+++ b/gcore/k8s/v2/pools/requests.go
@@ -28,6 +28,8 @@ type CreateOpts struct {
 	IsPublicIPv4       bool                           `json:"is_public_ipv4,omitempty"`
 	Labels             map[string]string              `json:"labels,omitempty"`
 	Taints             map[string]string              `json:"taints,omitempty"`
+	CrioConfig         map[string]string              `json:"crio_config,omitempty" validate:"omitempty"`
+	KubeletConfig      map[string]string              `json:"kubelet_config,omitempty" validate:"omitempty"`
 }
 
 // Validate CreateOpts

--- a/gcore/k8s/v2/pools/results.go
+++ b/gcore/k8s/v2/pools/results.go
@@ -56,6 +56,8 @@ type ClusterPool struct {
 	ServerGroupPolicy  string             `json:"servergroup_policy"`
 	Labels             map[string]string  `json:"labels,omitempty"`
 	Taints             map[string]string  `json:"taints,omitempty"`
+	CrioConfig         map[string]string  `json:"crio_config,omitempty"`
+	KubeletConfig      map[string]string  `json:"kubelet_config,omitempty"`
 }
 
 // ClusterPoolPage is the page returned by a pager when traversing over a


### PR DESCRIPTION
**Changelog:**

- Add `Authentication.OIDC` settings to k8s clusters.
- Add `AutoscalerConfig` settings to k8s clusters.
- Add Hubble Relay / Hubble UI switches for k8s clusters using Cilium CNI.
- Add `CrioConfig` and `KubeletConfig` settings to k8s cluster pools.
- Add support for k8s `clusters.Update` request (authentication and autoscaler configuration).
- Fix typo in `Cilium.LoadBalancerMode` tag (`omitemtpy` => `omitempty`).