### PR TITLE
GCLOUD2-14662 Add missing timeouts to create pool opts

### DIFF
--- a/gcore/loadbalancer/v1/loadbalancers/requests.go
+++ b/gcore/loadbalancer/v1/loadbalancers/requests.go
@@ -116,6 +116,7 @@ type CreateHealthMonitorOpts struct {
 	MaxRetriesDown int                     `json:"max_retries_down,omitempty"`
 	HTTPMethod     *types.HTTPMethod       `json:"http_method,omitempty"`
 	URLPath        string                  `json:"url_path,omitempty"`
+	ExpectedCodes  string                  `json:"expected_codes,omitempty"`
 }
 
 // CreatePoolMemberOpts represents options used to create a loadbalancer listener pool member.
@@ -138,6 +139,9 @@ type CreatePoolOpts struct {
 	HealthMonitor         *CreateHealthMonitorOpts      `json:"healthmonitor,omitempty"`
 	LoadBalancerAlgorithm types.LoadBalancerAlgorithm   `json:"lb_algorithm,omitempty"`
 	SessionPersistence    *CreateSessionPersistenceOpts `json:"session_persistence,omitempty"`
+	TimeoutClientData     *int                          `json:"timeout_client_data,omitempty"`
+	TimeoutMemberData     *int                          `json:"timeout_member_data,omitempty"`
+	TimeoutMemberConnect  *int                          `json:"timeout_member_connect,omitempty"`
 }
 
 // CreateListenerOpts represents options used to create a loadbalancer listener.

--- a/gcore/region/v1/regions/testing/fixtures.go
+++ b/gcore/region/v1/regions/testing/fixtures.go
@@ -99,10 +99,10 @@ var (
 		TaskID:            nil,
 		EndpointType:      types.EndpointTypePublic,
 		ExternalNetworkID: "0521f854-8e34-4e67-8827-2aeb27fb3872",
-		SpiceProxyURL:     *spiceURL,
+		SpiceProxyURL:     spiceURL,
 		CreatedOn:         createdTime,
 		KeystoneID:        1,
-		Keystone: keystones.Keystone{
+		Keystone: &keystones.Keystone{
 			ID:                        1,
 			URL:                       *keystoneURL,
 			State:                     keystonetypes.KeystoneStateNew,


### PR DESCRIPTION
**Changelog**

- Added missing pool timeouts and health monitor expected codes to batch load balancer create request. We already had them for pool create but not batch lb create.
- Fixed build.