### PR TITLE
MKAAS-1327 Add subnet id to file shares

### DIFF
--- a/gcore/file_share/v1/file_shares/results.go
+++ b/gcore/file_share/v1/file_shares/results.go
@@ -52,6 +52,7 @@ type FileShare struct {
 	ShareNetworkName string                          `json:"share_network_name"`
 	NetworkID        string                          `json:"network_id"`
 	NetworkName      string                          `json:"network_name"`
+	SubnetID         string                          `json:"subnet_id"`
 	SubnetName       string                          `json:"subnet_name"`
 	ConnectionPoint  string                          `json:"connection_point"`
 	TaskID           *string                         `json:"task_id"`


### PR DESCRIPTION
**Changelog**

- Add `subnet_id` to sfs file share responses.