### PR TITLE
MKAAS-1438 Add k8s create/upgrade versions APIs

### DIFF
--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -17,7 +17,7 @@ const (
 
 var (
 	ClientType  string
-	ClientTypes = []string{ClientTypeToken, ClientTypePlatform}
+	ClientTypes = []string{ClientTypeToken, ClientTypePlatform, ClientTypeAPIToken}
 )
 
 var commonFlags = []cli.Flag{

--- a/client/k8s/v2/client/client.go
+++ b/client/k8s/v2/client/client.go
@@ -8,5 +8,9 @@ import (
 )
 
 func NewK8sClientV2(c *cli.Context) (*gcorecloud.ServiceClient, error) {
+	return common.BuildClient(c, "k8s", "v2")
+}
+
+func NewK8sClustersClientV2(c *cli.Context) (*gcorecloud.ServiceClient, error) {
 	return common.BuildClient(c, "k8s/clusters", "v2")
 }

--- a/client/k8s/v2/k8s/clusters.go
+++ b/client/k8s/v2/k8s/clusters.go
@@ -130,7 +130,7 @@ var clusterListSubCommand = cli.Command{
 	Usage:    "List clusters",
 	Category: "cluster",
 	Action: func(c *cli.Context) error {
-		client, err := client.NewK8sClientV2(c)
+		client, err := client.NewK8sClustersClientV2(c)
 		if err != nil {
 			_ = cli.ShowAppHelp(c)
 			return cli.NewExitError(err, 1)
@@ -155,7 +155,7 @@ var clusterGetSubCommand = cli.Command{
 			_ = cli.ShowCommandHelp(c, "show")
 			return err
 		}
-		client, err := client.NewK8sClientV2(c)
+		client, err := client.NewK8sClustersClientV2(c)
 		if err != nil {
 			_ = cli.ShowAppHelp(c)
 			return cli.NewExitError(err, 1)
@@ -261,7 +261,7 @@ var clusterCreateSubCommand = cli.Command{
 	}, flags.WaitCommandFlags...),
 	Action: func(c *cli.Context) error {
 		clusterName := c.String("name")
-		client, err := client.NewK8sClientV2(c)
+		client, err := client.NewK8sClustersClientV2(c)
 		if err != nil {
 			_ = cli.ShowAppHelp(c)
 			return cli.NewExitError(err, 1)
@@ -321,7 +321,7 @@ var clusterUpgradeSubCommand = cli.Command{
 			_ = cli.ShowCommandHelp(c, "upgrade")
 			return err
 		}
-		client, err := client.NewK8sClientV2(c)
+		client, err := client.NewK8sClustersClientV2(c)
 		if err != nil {
 			_ = cli.ShowAppHelp(c)
 			return cli.NewExitError(err, 1)
@@ -356,7 +356,7 @@ var clusterDeleteSubCommand = cli.Command{
 			_ = cli.ShowCommandHelp(c, "delete")
 			return err
 		}
-		client, err := client.NewK8sClientV2(c)
+		client, err := client.NewK8sClustersClientV2(c)
 		if err != nil {
 			_ = cli.ShowAppHelp(c)
 			return cli.NewExitError(err, 1)
@@ -392,7 +392,7 @@ var clusterCertificateSubCommand = cli.Command{
 			_ = cli.ShowCommandHelp(c, "certificate")
 			return err
 		}
-		client, err := client.NewK8sClientV2(c)
+		client, err := client.NewK8sClustersClientV2(c)
 		if err != nil {
 			_ = cli.ShowAppHelp(c)
 			return cli.NewExitError(err, 1)
@@ -443,7 +443,7 @@ var clusterConfigSubCommand = cli.Command{
 			_ = cli.ShowCommandHelp(c, "config")
 			return err
 		}
-		client, err := client.NewK8sClientV2(c)
+		client, err := client.NewK8sClustersClientV2(c)
 		if err != nil {
 			_ = cli.ShowAppHelp(c)
 			return cli.NewExitError(err, 1)
@@ -488,9 +488,9 @@ var clusterConfigSubCommand = cli.Command{
 	},
 }
 
-var clusterVersionsSubCommand = cli.Command{
-	Name:     "versions",
-	Usage:    "List supported k8s versions",
+var clusterCreateVersionsSubCommand = cli.Command{
+	Name:     "create-versions",
+	Usage:    "List supported k8s versions for cluster creation",
 	Category: "cluster",
 	Action: func(c *cli.Context) error {
 		client, err := client.NewK8sClientV2(c)
@@ -498,7 +498,32 @@ var clusterVersionsSubCommand = cli.Command{
 			_ = cli.ShowAppHelp(c)
 			return cli.NewExitError(err, 1)
 		}
-		results, err := clusters.VersionsAll(client)
+		results, err := clusters.CreateVersionsAll(client)
+		if err != nil {
+			return cli.NewExitError(err, 1)
+		}
+		utils.ShowResults(results, c.String("format"))
+		return nil
+	},
+}
+
+var clusterUpgradeVersionsSubCommand = cli.Command{
+	Name:      "upgrade-versions",
+	Usage:     "List supported k8s versions for cluster upgrade",
+	ArgsUsage: "<cluster_name>",
+	Category:  "cluster",
+	Action: func(c *cli.Context) error {
+		clusterName, err := flags.GetFirstStringArg(c, clusterNameText)
+		if err != nil {
+			_ = cli.ShowCommandHelp(c, "upgrade")
+			return err
+		}
+		client, err := client.NewK8sClustersClientV2(c)
+		if err != nil {
+			_ = cli.ShowAppHelp(c)
+			return cli.NewExitError(err, 1)
+		}
+		results, err := clusters.UpgradeVersionsAll(client, clusterName)
 		if err != nil {
 			return cli.NewExitError(err, 1)
 		}
@@ -518,7 +543,7 @@ var clusterInstancesSubCommand = cli.Command{
 			_ = cli.ShowCommandHelp(c, "instances")
 			return err
 		}
-		client, err := client.NewK8sClientV2(c)
+		client, err := client.NewK8sClustersClientV2(c)
 		if err != nil {
 			_ = cli.ShowAppHelp(c)
 			return cli.NewExitError(err, 1)
@@ -543,7 +568,8 @@ var Commands = cli.Command{
 		&clusterDeleteSubCommand,
 		&clusterCertificateSubCommand,
 		&clusterConfigSubCommand,
-		&clusterVersionsSubCommand,
+		&clusterCreateVersionsSubCommand,
+		&clusterUpgradeVersionsSubCommand,
 		&clusterInstancesSubCommand,
 		&poolCommands,
 	},

--- a/client/k8s/v2/k8s/pools.go
+++ b/client/k8s/v2/k8s/pools.go
@@ -32,7 +32,7 @@ var poolListSubCommand = cli.Command{
 	},
 	Action: func(c *cli.Context) error {
 		clusterName := c.String("cluster-name")
-		client, err := client.NewK8sClientV2(c)
+		client, err := client.NewK8sClustersClientV2(c)
 		if err != nil {
 			_ = cli.ShowAppHelp(c)
 			return cli.NewExitError(err, 1)
@@ -66,7 +66,7 @@ var poolGetSubCommand = cli.Command{
 			return cli.NewExitError(err, 1)
 		}
 		clusterName := c.String("cluster-name")
-		client, err := client.NewK8sClientV2(c)
+		client, err := client.NewK8sClustersClientV2(c)
 		if err != nil {
 			_ = cli.ShowAppHelp(c)
 			return cli.NewExitError(err, 1)
@@ -145,7 +145,7 @@ var poolCreateSubCommand = cli.Command{
 	Action: func(c *cli.Context) error {
 		clusterName := c.String("cluster-name")
 		poolName := c.String("name")
-		client, err := client.NewK8sClientV2(c)
+		client, err := client.NewK8sClustersClientV2(c)
 		if err != nil {
 			_ = cli.ShowAppHelp(c)
 			return cli.NewExitError(err, 1)
@@ -210,7 +210,7 @@ var poolUpdateSubCommand = cli.Command{
 			return cli.NewExitError(err, 1)
 		}
 		clusterName := c.String("cluster-name")
-		client, err := client.NewK8sClientV2(c)
+		client, err := client.NewK8sClustersClientV2(c)
 		if err != nil {
 			_ = cli.ShowAppHelp(c)
 			return cli.NewExitError(err, 1)
@@ -255,7 +255,7 @@ var poolResizeSubCommand = cli.Command{
 			return cli.NewExitError(err, 1)
 		}
 		clusterName := c.String("cluster-name")
-		client, err := client.NewK8sClientV2(c)
+		client, err := client.NewK8sClustersClientV2(c)
 		if err != nil {
 			_ = cli.ShowAppHelp(c)
 			return cli.NewExitError(err, 1)
@@ -298,7 +298,7 @@ var poolDeleteSubCommand = cli.Command{
 			return cli.NewExitError(err, 1)
 		}
 		clusterName := c.String("cluster-name")
-		client, err := client.NewK8sClientV2(c)
+		client, err := client.NewK8sClustersClientV2(c)
 		if err != nil {
 			_ = cli.ShowAppHelp(c)
 			return cli.NewExitError(err, 1)
@@ -343,7 +343,7 @@ var poolInstancesSubCommand = cli.Command{
 			return cli.NewExitError(err, 1)
 		}
 		clusterName := c.String("cluster-name")
-		client, err := client.NewK8sClientV2(c)
+		client, err := client.NewK8sClustersClientV2(c)
 		if err != nil {
 			_ = cli.ShowAppHelp(c)
 			return cli.NewExitError(err, 1)

--- a/gcore/k8s/v2/clusters/requests.go
+++ b/gcore/k8s/v2/clusters/requests.go
@@ -253,18 +253,36 @@ func Upgrade(c *gcorecloud.ServiceClient, clusterID string, opts UpgradeOptsBuil
 	return
 }
 
-// Versions returns a Pager which allows you to iterate over a collection of
-// supported cluster versions.
-func Versions(c *gcorecloud.ServiceClient) pagination.Pager {
-	url := versionsURL(c)
+// CreateVersions returns a Pager which allows you to iterate over a collection of
+// supported k8s versions for cluster creation.
+func CreateVersions(c *gcorecloud.ServiceClient) pagination.Pager {
+	url := createVersionsURL(c)
 	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
 		return VersionPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
 
-// VersionsAll is a convenience function that returns all supported cluster versions.
-func VersionsAll(c *gcorecloud.ServiceClient) ([]Version, error) {
-	page, err := Versions(c).AllPages()
+// CreateVersionsAll is a convenience function that returns all supported k8s versions for cluster creation.
+func CreateVersionsAll(c *gcorecloud.ServiceClient) ([]Version, error) {
+	page, err := CreateVersions(c).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	return ExtractVersions(page)
+}
+
+// UpgradeVersions returns a Pager which allows you to iterate over a collection of
+// supported k8s versions for cluster upgrade.
+func UpgradeVersions(c *gcorecloud.ServiceClient, clusterID string) pagination.Pager {
+	url := upgradeVersionsURL(c, clusterID)
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return VersionPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// UpgradeVersionsAll is a convenience function that returns all supported k8s versions for cluster upgrade.
+func UpgradeVersionsAll(c *gcorecloud.ServiceClient, clusterID string) ([]Version, error) {
+	page, err := UpgradeVersions(c, clusterID).AllPages()
 	if err != nil {
 		return nil, err
 	}

--- a/gcore/k8s/v2/clusters/urls.go
+++ b/gcore/k8s/v2/clusters/urls.go
@@ -54,6 +54,10 @@ func upgradeURL(c *gcorecloud.ServiceClient, clusterName string) string {
 	return resourceActionURL(c, clusterName, "upgrade")
 }
 
-func versionsURL(c *gcorecloud.ServiceClient) string {
-	return c.BaseServiceURL("k8s", "versions")
+func createVersionsURL(c *gcorecloud.ServiceClient) string {
+	return c.ServiceURL("create_versions")
+}
+
+func upgradeVersionsURL(c *gcorecloud.ServiceClient, clusterName string) string {
+	return resourceActionURL(c, clusterName, "upgrade_versions")
 }


### PR DESCRIPTION
**Changelog**

- Add support for k8s cluster create_versions and upgrade_versions APIs.
- Add `create-versions` and `upgrade-versions` subcommands to `./gcoreclient cluster` cmd.
- Fix `ERRO[0000] Cannot initialize application: allowed values are token, platform` error when trying to use API Token with gcoreclient CLI.
