### PR TITLE
GCLOUD2-14671 Set correct AppVersion in request's User-Agent header and cmd version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - '-s -w -X gcorecloud.AppVersion={{.Version}}'
+      - '-s -w -X github.com/G-Core/gcorelabscloud-go.AppVersion={{.Version}} -X 'github.com/G-Core/gcorelabscloud-go/cmd.AppVersion={{.Version}}'
     goos:
       - windows
       - linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - '-s -w -X github.com/G-Core/gcorelabscloud-go.AppVersion={{.Version}} -X 'github.com/G-Core/gcorelabscloud-go/cmd.AppVersion={{.Version}}'
+      - '-s -w -X github.com/G-Core/gcorelabscloud-go.AppVersion={{.Version}} -X github.com/G-Core/gcorelabscloud-go/cmd.AppVersion={{.Version}}'
     goos:
       - windows
       - linux

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ VERSION		?= $(shell git describe --tags 2> /dev/null || \
 			   git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
 GOARCH		?= $(shell go env GOARCH)
 TAGS		:=
-LDFLAGS		:= "-w -s -X 'github.com/G-Core/gcorelabscloud-go/gcorecloud.AppVersion=${VERSION}' -X 'github.com/G-Core/gcorelabscloud-go/cmd.AppVersion=${VERSION}'"
+LDFLAGS		:= "-w -s -X 'github.com/G-Core/gcorelabscloud-go/cmd.AppVersion=${VERSION}'"
 CMD_PACKAGE := ./cmd/gcoreclient
 BINARY 		:= ./gcoreclient
 

--- a/provider_client.go
+++ b/provider_client.go
@@ -18,9 +18,9 @@ import (
 )
 
 // DefaultUserAgent is the default User-Agent string set in the request header.
-const DefaultUserAgent = "CloudAPI-GoLib/%s"
+const DefaultUserAgent = "cloud-api-go-sdk/%s"
 
-var AppVersion = "0.0.1"
+var AppVersion = "dev"
 
 // UserAgent represents a User-Agent header.
 type UserAgent struct {


### PR DESCRIPTION
The default UserAgent was being set with an incorrect default value, this MR sets the default with the value coming from the release version.