### PR TITLE
Bugfix/poplar count int

### DIFF
--- a/gcore/ai/v1/aiflavors/results.go
+++ b/gcore/ai/v1/aiflavors/results.go
@@ -60,7 +60,6 @@ func ExtractAIFlavorsInto(r pagination.Page, v interface{}) error {
 	return r.(AIFlavorPage).Result.ExtractIntoSlicePtr(v, "results")
 }
 
-
 type HardwareDescription struct {
 	CPU         string `json:"cpu,omitempty"`
 	Disk        string `json:"disk,omitempty"`
@@ -69,7 +68,7 @@ type HardwareDescription struct {
 	Ephemeral   string `json:"ephemeral,omitempty"`
 	GPU         string `json:"gpu,omitempty"`
 	IPU         string `json:"ipu,omitempty"`
-	PoplarCount string `json:"poplar_count,omitempty"`
+	PoplarCount int    `json:"poplar_count,omitempty"`
 	SGXEPCSize  string `json:"sgx_epc_size,omitempty"`
 }
 
@@ -84,8 +83,7 @@ type AIFlavor struct {
 	PricePerHour        *decimal.Decimal     `json:"price_per_hour,omitempty"`
 	PricePerMonth       *decimal.Decimal     `json:"price_per_month,omitempty"`
 	HardwareDescription *HardwareDescription `json:"hardware_description,omitempty"`
-	RAM                 *int                  `json:"ram,omitempty"`
-	VCPUS               *int                  `json:"vcpus,omitempty"`
-	Capacity            *int                  `json:"capacity,omitempty"`
+	RAM                 *int                 `json:"ram,omitempty"`
+	VCPUS               *int                 `json:"vcpus,omitempty"`
+	Capacity            *int                 `json:"capacity,omitempty"`
 }
-

--- a/gcore/ai/v1/aiflavors/testing/fixtures.go
+++ b/gcore/ai/v1/aiflavors/testing/fixtures.go
@@ -13,7 +13,7 @@ const ListResponse = `
             "hardware_description": {
                 "network": "2x100G",
                 "ipu": "vPOD-16 (Classic)",
-                "poplar_count": "2"
+                "poplar_count": 2
             },
             "disabled": false,
             "flavor_name": "bm1-ai-2xsmall-v1pod-16",
@@ -32,7 +32,7 @@ var (
 		HardwareDescription: &aiflavors.HardwareDescription{
 			Network:     "2x100G",
 			IPU:         "vPOD-16 (Classic)",
-			PoplarCount: "2",
+			PoplarCount: 2,
 		},
 	}
 	ExpectedAIFlavorSlice = []aiflavors.AIFlavor{AIFlavor1}


### PR DESCRIPTION
Fix for error
`./gcoreclient ai flavor list` 
json: cannot unmarshal number into Go struct field HardwareDescription.hardware_description.poplar_count of type string