### PR TITLE
GCLOUD2-17074 Add GPU image upload support

### DIFF
--- a/client/gpu/v3/client/client.go
+++ b/client/gpu/v3/client/client.go
@@ -7,12 +7,12 @@ import (
 	"github.com/G-Core/gcorelabscloud-go/client/common"
 )
 
-// NewGPUImageClientV3 creates a new GPU image client
-func NewGPUImageClientV3(c *cli.Context) (*gcorecloud.ServiceClient, error) {
-	client, err := common.BuildClient(c, "gpu/baremetal", "v3")
-	if err != nil {
-		return nil, err
-	}
+// NewGPUBaremetalClientV3 creates a new GPU baremetal client
+func NewGPUBaremetalClientV3(c *cli.Context) (*gcorecloud.ServiceClient, error) {
+	return common.BuildClient(c, "gpu/baremetal", "v3")
+}
 
-	return client, nil
+// NewGPUVirtualClientV3 creates a new GPU virtual client
+func NewGPUVirtualClientV3(c *cli.Context) (*gcorecloud.ServiceClient, error) {
+	return common.BuildClient(c, "gpu/virtual", "v3")
 }

--- a/client/gpu/v3/client/client.go
+++ b/client/gpu/v3/client/client.go
@@ -9,11 +9,10 @@ import (
 
 // NewGPUImageClientV3 creates a new GPU image client
 func NewGPUImageClientV3(c *cli.Context) (*gcorecloud.ServiceClient, error) {
-	client, err := common.BuildClient(c, "gpu", "v3")
+	client, err := common.BuildClient(c, "gpu/baremetal", "v3")
 	if err != nil {
 		return nil, err
 	}
 
-	// BuildClient already adds the version prefix and base path
 	return client, nil
 }

--- a/client/gpu/v3/client/client.go
+++ b/client/gpu/v3/client/client.go
@@ -9,5 +9,11 @@ import (
 
 // NewGPUImageClientV3 creates a new GPU image client
 func NewGPUImageClientV3(c *cli.Context) (*gcorecloud.ServiceClient, error) {
-	return common.BuildClient(c, "gpu/images", "v3")
+	client, err := common.BuildClient(c, "gpu", "v3")
+	if err != nil {
+		return nil, err
+	}
+
+	// BuildClient already adds the version prefix and base path
+	return client, nil
 }

--- a/client/gpu/v3/client/client.go
+++ b/client/gpu/v3/client/client.go
@@ -1,0 +1,13 @@
+package client
+
+import (
+	"github.com/urfave/cli/v2"
+
+	gcorecloud "github.com/G-Core/gcorelabscloud-go"
+	"github.com/G-Core/gcorelabscloud-go/client/common"
+)
+
+// NewGPUImageClientV3 creates a new GPU image client
+func NewGPUImageClientV3(c *cli.Context) (*gcorecloud.ServiceClient, error) {
+	return common.BuildClient(c, "gpu/images", "v3")
+}

--- a/client/gpu/v3/images/commands.go
+++ b/client/gpu/v3/images/commands.go
@@ -19,7 +19,7 @@ func stringToMap(slice []string) (map[string]string, error) {
 	for _, s := range slice {
 		parts := strings.SplitN(s, "=", 2)
 		if len(parts) != 2 {
-			return nil, cli.NewExitError("invalid metadata format", 1)
+			return nil, cli.Exit("invalid metadata format", 1)
 		}
 		result[parts[0]] = parts[1]
 	}
@@ -157,13 +157,13 @@ func uploadImageAction(c *cli.Context, newClient func(*cli.Context) (*gcorecloud
 	// Only validate if not showing help
 	if !c.Bool("help") && (c.String("url") == "" || c.String("name") == "") {
 		_ = cli.ShowCommandHelp(c, "")
-		return cli.NewExitError("Required flags 'url' and 'name' must be set", 1)
+		return cli.Exit("Required flags 'url' and 'name' must be set", 1)
 	}
 
 	client, err := newClient(c)
 	if err != nil {
 		_ = cli.ShowAppHelp(c)
-		return cli.NewExitError(err, 1)
+		return cli.Exit(err, 1)
 	}
 
 	sshKey := images.SshKeyType(c.String("ssh-key"))
@@ -185,7 +185,7 @@ func uploadImageAction(c *cli.Context, newClient func(*cli.Context) (*gcorecloud
 	if c.IsSet("metadata") {
 		metadata, err := stringToMap(c.StringSlice("metadata"))
 		if err != nil {
-			return cli.NewExitError(err, 1)
+			return cli.Exit(err, 1)
 		}
 		metadataInterface := make(map[string]interface{})
 		for k, v := range metadata {
@@ -197,12 +197,12 @@ func uploadImageAction(c *cli.Context, newClient func(*cli.Context) (*gcorecloud
 	serviceClient := &images.ServiceClient{ServiceClient: client}
 	results, err := serviceClient.UploadImage(opts)
 	if err != nil {
-		return cli.NewExitError(err, 1)
+		return cli.Exit(err, 1)
 	}
 
 	taskClient, err := taskclient.NewTaskClientV1(c)
 	if err != nil {
-		return cli.NewExitError(err, 1)
+		return cli.Exit(err, 1)
 	}
 
 	return utils.WaitTaskAndShowResult(c, taskClient, results, true, func(task tasks.TaskID) (interface{}, error) {

--- a/client/gpu/v3/images/commands.go
+++ b/client/gpu/v3/images/commands.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/G-Core/gcorelabscloud-go/client/flags"
 	"github.com/G-Core/gcorelabscloud-go/client/gpu/v3/client"
+	taskclient "github.com/G-Core/gcorelabscloud-go/client/tasks/v1/client"
 	"github.com/G-Core/gcorelabscloud-go/client/utils"
 	"github.com/G-Core/gcorelabscloud-go/gcore/gpu/v3/images"
 	"github.com/G-Core/gcorelabscloud-go/gcore/task/v1/tasks"
@@ -183,7 +184,12 @@ func uploadBaremetalImageAction(c *cli.Context) error {
 		return cli.NewExitError(err, 1)
 	}
 
-	return utils.WaitTaskAndShowResult(c, client, results, true, func(task tasks.TaskID) (interface{}, error) {
+	taskClient, err := taskclient.NewTaskClientV1(c)
+	if err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	return utils.WaitTaskAndShowResult(c, taskClient, results, true, func(task tasks.TaskID) (interface{}, error) {
 		return task, nil
 	})
 }
@@ -240,7 +246,12 @@ func uploadVirtualImageAction(c *cli.Context) error {
 		return cli.NewExitError(err, 1)
 	}
 
-	return utils.WaitTaskAndShowResult(c, client, results, true, func(task tasks.TaskID) (interface{}, error) {
+	taskClient, err := taskclient.NewTaskClientV1(c)
+	if err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	return utils.WaitTaskAndShowResult(c, taskClient, results, true, func(task tasks.TaskID) (interface{}, error) {
 		return task, nil
 	})
 }

--- a/client/gpu/v3/images/commands.go
+++ b/client/gpu/v3/images/commands.go
@@ -183,8 +183,7 @@ func uploadBaremetalImageAction(c *cli.Context) error {
 		return cli.NewExitError(err, 1)
 	}
 
-	taskResults := &tasks.TaskResults{Tasks: []tasks.TaskID{tasks.TaskID(results.ID)}}
-	return utils.WaitTaskAndShowResult(c, client, taskResults, true, func(task tasks.TaskID) (interface{}, error) {
+	return utils.WaitTaskAndShowResult(c, client, results, true, func(task tasks.TaskID) (interface{}, error) {
 		return task, nil
 	})
 }
@@ -241,8 +240,7 @@ func uploadVirtualImageAction(c *cli.Context) error {
 		return cli.NewExitError(err, 1)
 	}
 
-	taskResults := &tasks.TaskResults{Tasks: []tasks.TaskID{tasks.TaskID(results.ID)}}
-	return utils.WaitTaskAndShowResult(c, client, taskResults, true, func(task tasks.TaskID) (interface{}, error) {
+	return utils.WaitTaskAndShowResult(c, client, results, true, func(task tasks.TaskID) (interface{}, error) {
 		return task, nil
 	})
 }

--- a/client/gpu/v3/images/commands.go
+++ b/client/gpu/v3/images/commands.go
@@ -85,12 +85,20 @@ var uploadBaremetalCommand = cli.Command{
 	Subcommands: []*cli.Command{
 		{
 			Name:        "images",
-			Usage:       "Upload baremetal GPU image",
-			Description: "Upload a new baremetal GPU image with the specified URL and name",
+			Usage:       "Manage baremetal GPU images",
+			Description: "Commands for managing baremetal GPU images",
 			Category:    "images",
-			ArgsUsage:   " ",
-			Flags:       append(imageUploadFlags, flags.WaitCommandFlags...),
-			Action:      uploadBaremetalImageAction,
+			Subcommands: []*cli.Command{
+				{
+					Name:        "upload",
+					Usage:       "Upload baremetal GPU image",
+					Description: "Upload a new baremetal GPU image with the specified URL and name",
+					Category:    "images",
+					ArgsUsage:   " ",
+					Flags:       append(imageUploadFlags, flags.WaitCommandFlags...),
+					Action:      uploadBaremetalImageAction,
+				},
+			},
 		},
 	},
 }
@@ -102,12 +110,20 @@ var uploadVirtualCommand = cli.Command{
 	Subcommands: []*cli.Command{
 		{
 			Name:        "images",
-			Usage:       "Upload virtual GPU image",
-			Description: "Upload a new virtual GPU image with the specified URL and name",
+			Usage:       "Manage virtual GPU images",
+			Description: "Commands for managing virtual GPU images",
 			Category:    "images",
-			ArgsUsage:   " ",
-			Flags:       append(imageUploadFlags, flags.WaitCommandFlags...),
-			Action:      uploadVirtualImageAction,
+			Subcommands: []*cli.Command{
+				{
+					Name:        "upload",
+					Usage:       "Upload virtual GPU image",
+					Description: "Upload a new virtual GPU image with the specified URL and name",
+					Category:    "images",
+					ArgsUsage:   " ",
+					Flags:       append(imageUploadFlags, flags.WaitCommandFlags...),
+					Action:      uploadVirtualImageAction,
+				},
+			},
 		},
 	},
 }

--- a/client/gpu/v3/images/commands.go
+++ b/client/gpu/v3/images/commands.go
@@ -148,6 +148,9 @@ func uploadBaremetalImageAction(c *cli.Context) error {
 		return cli.NewExitError(err, 1)
 	}
 
+	// Update the client endpoint to use the correct URL structure
+	client.ResourceBase = strings.TrimSuffix(client.ResourceBase, "/") + "/baremetal/"
+
 	sshKey := images.SshKeyType(c.String("ssh-key"))
 	cowFormat := c.Bool("cow-format")
 	osType := images.ImageOsType(c.String("os-type"))
@@ -205,6 +208,9 @@ func uploadVirtualImageAction(c *cli.Context) error {
 		_ = cli.ShowAppHelp(c)
 		return cli.NewExitError(err, 1)
 	}
+
+	// Update the client endpoint to use the correct URL structure
+	client.ResourceBase = strings.TrimSuffix(client.ResourceBase, "/") + "/virtual/"
 
 	sshKey := images.SshKeyType(c.String("ssh-key"))
 	cowFormat := c.Bool("cow-format")

--- a/client/gpu/v3/images/commands.go
+++ b/client/gpu/v3/images/commands.go
@@ -147,9 +147,8 @@ func uploadBaremetalImageAction(c *cli.Context) error {
 		_ = cli.ShowAppHelp(c)
 		return cli.NewExitError(err, 1)
 	}
+	
 
-	// Update the client endpoint to use the correct URL structure
-	client.ResourceBase = strings.TrimSuffix(client.ResourceBase, "/") + "/baremetal/"
 
 	sshKey := images.SshKeyType(c.String("ssh-key"))
 	cowFormat := c.Bool("cow-format")
@@ -209,8 +208,7 @@ func uploadVirtualImageAction(c *cli.Context) error {
 		return cli.NewExitError(err, 1)
 	}
 
-	// Update the client endpoint to use the correct URL structure
-	client.ResourceBase = strings.TrimSuffix(client.ResourceBase, "/") + "/virtual/"
+
 
 	sshKey := images.SshKeyType(c.String("ssh-key"))
 	cowFormat := c.Bool("cow-format")

--- a/client/gpu/v3/images/commands.go
+++ b/client/gpu/v3/images/commands.go
@@ -142,13 +142,11 @@ func uploadBaremetalImageAction(c *cli.Context) error {
 		return cli.NewExitError("Required flags 'url' and 'name' must be set", 1)
 	}
 
-	client, err := client.NewGPUImageClientV3(c)
+	client, err := client.NewGPUBaremetalClientV3(c)
 	if err != nil {
 		_ = cli.ShowAppHelp(c)
 		return cli.NewExitError(err, 1)
 	}
-	
-
 
 	sshKey := images.SshKeyType(c.String("ssh-key"))
 	cowFormat := c.Bool("cow-format")
@@ -202,13 +200,11 @@ func uploadVirtualImageAction(c *cli.Context) error {
 		return cli.NewExitError("Required flags 'url' and 'name' must be set", 1)
 	}
 
-	client, err := client.NewGPUImageClientV3(c)
+	client, err := client.NewGPUVirtualClientV3(c)
 	if err != nil {
 		_ = cli.ShowAppHelp(c)
 		return cli.NewExitError(err, 1)
 	}
-
-
 
 	sshKey := images.SshKeyType(c.String("ssh-key"))
 	cowFormat := c.Bool("cow-format")

--- a/client/gpu/v3/images/commands.go
+++ b/client/gpu/v3/images/commands.go
@@ -1,0 +1,236 @@
+package images
+
+import (
+	"strings"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/G-Core/gcorelabscloud-go/client/flags"
+	"github.com/G-Core/gcorelabscloud-go/client/gpu/v3/client"
+	"github.com/G-Core/gcorelabscloud-go/client/utils"
+	"github.com/G-Core/gcorelabscloud-go/gcore/gpu/v3/images"
+	"github.com/G-Core/gcorelabscloud-go/gcore/task/v1/tasks"
+)
+
+func stringToMap(slice []string) (map[string]string, error) {
+	result := make(map[string]string)
+	for _, s := range slice {
+		parts := strings.SplitN(s, "=", 2)
+		if len(parts) != 2 {
+			return nil, cli.NewExitError("invalid metadata format", 1)
+		}
+		result[parts[0]] = parts[1]
+	}
+	return result, nil
+}
+
+var imageUploadFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:     "url",
+		Usage:    "Image URL",
+		Required: true,
+	},
+	&cli.StringFlag{
+		Name:     "name",
+		Usage:    "Image name",
+		Required: true,
+	},
+	&cli.StringFlag{
+		Name:     "ssh-key",
+		Usage:    "Permission to use SSH key in instances (allow/deny)",
+		Required: false,
+	},
+	&cli.BoolFlag{
+		Name:     "cow-format",
+		Usage:    "When True, image cannot be deleted unless all volumes created from it are deleted",
+		Required: false,
+	},
+	&cli.StringFlag{
+		Name:     "architecture",
+		Usage:    "Image architecture type (aarch64/x86_64)",
+		Required: false,
+	},
+	&cli.StringFlag{
+		Name:     "os-distro",
+		Usage:    "OS Distribution (Debian/CentOS/Ubuntu/etc)",
+		Required: false,
+	},
+	&cli.StringFlag{
+		Name:     "os-type",
+		Usage:    "Operating system type (linux/windows)",
+		Required: false,
+	},
+	&cli.StringFlag{
+		Name:     "os-version",
+		Usage:    "OS version",
+		Required: false,
+	},
+	&cli.StringFlag{
+		Name:     "hw-firmware-type",
+		Usage:    "Type of firmware for booting the guest (bios/uefi)",
+		Required: false,
+	},
+	&cli.StringSliceFlag{
+		Name:     "metadata",
+		Usage:    "Image metadata (key=value)",
+		Required: false,
+	},
+}
+
+var uploadBaremetalCommand = cli.Command{
+	Name:        "baremetal",
+	Usage:       "Upload baremetal GPU image",
+	Description: "Upload a new baremetal GPU image with the specified URL and name",
+	Category:    "images",
+	ArgsUsage:   " ",
+	Flags:       append(imageUploadFlags, flags.WaitCommandFlags...),
+	Action: func(c *cli.Context) error {
+		if c.Args().Len() > 0 {
+			return cli.ShowCommandHelp(c, "")
+		}
+
+		// Only validate if not showing help
+		if !c.Bool("help") && (c.String("url") == "" || c.String("name") == "") {
+			_ = cli.ShowCommandHelp(c, "")
+			return cli.NewExitError("Required flags 'url' and 'name' must be set", 1)
+		}
+
+		client, err := client.NewGPUImageClientV3(c)
+		if err != nil {
+			_ = cli.ShowAppHelp(c)
+			return cli.NewExitError(err, 1)
+		}
+
+		sshKey := images.SshKeyType(c.String("ssh-key"))
+		cowFormat := c.Bool("cow-format")
+		osType := images.ImageOsType(c.String("os-type"))
+		hwType := images.ImageHwFirmwareType(c.String("hw-firmware-type"))
+
+		opts := images.UploadBaremetalImageOpts{
+			URL:            c.String("url"),
+			Name:           c.String("name"),
+			SshKey:         &sshKey,
+			CowFormat:      &cowFormat,
+			Architecture:   stringPtr(c.String("architecture")),
+			OsDistro:       stringPtr(c.String("os-distro")),
+			OsType:         &osType,
+			OsVersion:      stringPtr(c.String("os-version")),
+			HwFirmwareType: &hwType,
+		}
+
+		if c.IsSet("metadata") {
+			metadata, err := stringToMap(c.StringSlice("metadata"))
+			if err != nil {
+				return cli.NewExitError(err, 1)
+			}
+			metadataInterface := make(map[string]interface{})
+			for k, v := range metadata {
+				metadataInterface[k] = v
+			}
+			opts.Metadata = metadataInterface
+		}
+
+		serviceClient := &images.ServiceClient{ServiceClient: client}
+		results, err := serviceClient.UploadBaremetalImage(opts)
+		if err != nil {
+			return cli.NewExitError(err, 1)
+		}
+
+		taskResults := &tasks.TaskResults{Tasks: []tasks.TaskID{tasks.TaskID(results.ID)}}
+		return utils.WaitTaskAndShowResult(c, client, taskResults, true, func(task tasks.TaskID) (interface{}, error) {
+			return task, nil
+		})
+	},
+}
+
+var uploadVirtualCommand = cli.Command{
+	Name:        "virtual",
+	Usage:       "Upload virtual GPU image",
+	Description: "Upload a new virtual GPU image with the specified URL and name",
+	Category:    "images",
+	ArgsUsage:   " ",
+	Flags:       append(imageUploadFlags, flags.WaitCommandFlags...),
+	Action: func(c *cli.Context) error {
+		if c.Args().Len() > 0 {
+			return cli.ShowCommandHelp(c, "")
+		}
+
+		// Only validate if not showing help
+		if !c.Bool("help") && (c.String("url") == "" || c.String("name") == "") {
+			_ = cli.ShowCommandHelp(c, "")
+			return cli.NewExitError("Required flags 'url' and 'name' must be set", 1)
+		}
+
+		client, err := client.NewGPUImageClientV3(c)
+		if err != nil {
+			_ = cli.ShowAppHelp(c)
+			return cli.NewExitError(err, 1)
+		}
+
+		sshKey := images.SshKeyType(c.String("ssh-key"))
+		cowFormat := c.Bool("cow-format")
+		osType := images.ImageOsType(c.String("os-type"))
+		hwType := images.ImageHwFirmwareType(c.String("hw-firmware-type"))
+
+		opts := images.UploadVirtualImageOpts{
+			URL:            c.String("url"),
+			Name:           c.String("name"),
+			SshKey:         &sshKey,
+			CowFormat:      &cowFormat,
+			Architecture:   stringPtr(c.String("architecture")),
+			OsDistro:       stringPtr(c.String("os-distro")),
+			OsType:         &osType,
+			OsVersion:      stringPtr(c.String("os-version")),
+			HwFirmwareType: &hwType,
+		}
+
+		if c.IsSet("metadata") {
+			metadata, err := stringToMap(c.StringSlice("metadata"))
+			if err != nil {
+				return cli.NewExitError(err, 1)
+			}
+			metadataInterface := make(map[string]interface{})
+			for k, v := range metadata {
+				metadataInterface[k] = v
+			}
+			opts.Metadata = metadataInterface
+		}
+
+		serviceClient := &images.ServiceClient{ServiceClient: client}
+		results, err := serviceClient.UploadVirtualImage(opts)
+		if err != nil {
+			return cli.NewExitError(err, 1)
+		}
+
+		taskResults := &tasks.TaskResults{Tasks: []tasks.TaskID{tasks.TaskID(results.ID)}}
+		return utils.WaitTaskAndShowResult(c, client, taskResults, true, func(task tasks.TaskID) (interface{}, error) {
+			return task, nil
+		})
+	},
+}
+
+func stringPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// Commands returns the list of GPU image commands
+var Commands = cli.Command{
+	Name:        "gpu",
+	Usage:       "Manage GPU resources",
+	Description: "Parent command for GPU-related operations",
+	Category:    "gpu",
+	Subcommands: []*cli.Command{
+		{
+			Name:        "images",
+			Usage:       "Manage GPU images",
+			Description: "Upload and manage GPU images for both baremetal and virtual instances",
+			Subcommands: []*cli.Command{
+				&uploadBaremetalCommand,
+				&uploadVirtualCommand,
+			},
+		},
+	},
+}

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -13,6 +13,7 @@ import (
 	"github.com/G-Core/gcorelabscloud-go/client/flags"
 	"github.com/G-Core/gcorelabscloud-go/client/flavors/v1/flavors"
 	"github.com/G-Core/gcorelabscloud-go/client/floatingips/v1/floatingips"
+	gpuimages "github.com/G-Core/gcorelabscloud-go/client/gpu/v3/images"
 	"github.com/G-Core/gcorelabscloud-go/client/heat"
 	"github.com/G-Core/gcorelabscloud-go/client/images/v1/images"
 	"github.com/G-Core/gcorelabscloud-go/client/instances/v1/instances"
@@ -79,6 +80,7 @@ var commands = []*cli.Command{
 	&file_shares.Commands,
 	&ais.Commands,
 	&functions.Commands,
+	&gpuimages.Commands,
 }
 
 type clientCommands struct {

--- a/gcore/gpu/v3/images/client.go
+++ b/gcore/gpu/v3/images/client.go
@@ -85,13 +85,13 @@ func (opts UploadVirtualImageOpts) ToImageCreateMap() (map[string]interface{}, e
 	return gcorecloud.BuildRequestBody(opts, "")
 }
 
-func (c *ServiceClient) UploadBaremetalImage(opts UploadBaremetalImageOpts) (*tasks.Task, error) {
+func (c *ServiceClient) UploadBaremetalImage(opts UploadBaremetalImageOpts) (*tasks.TaskResults, error) {
 	url := UploadBaremetalURL(c.ServiceClient)
 	b, err := opts.ToImageCreateMap()
 	if err != nil {
 		return nil, err
 	}
-	var result tasks.Task
+	var result tasks.TaskResults
 	_, err = c.Post(url, b, &result, &gcorecloud.RequestOpts{
 		OkCodes: []int{200, 201, 202},
 	})
@@ -101,13 +101,13 @@ func (c *ServiceClient) UploadBaremetalImage(opts UploadBaremetalImageOpts) (*ta
 	return &result, nil
 }
 
-func (c *ServiceClient) UploadVirtualImage(opts UploadVirtualImageOpts) (*tasks.Task, error) {
+func (c *ServiceClient) UploadVirtualImage(opts UploadVirtualImageOpts) (*tasks.TaskResults, error) {
 	url := UploadVirtualURL(c.ServiceClient)
 	b, err := opts.ToImageCreateMap()
 	if err != nil {
 		return nil, err
 	}
-	var result tasks.Task
+	var result tasks.TaskResults
 	_, err = c.Post(url, b, &result, &gcorecloud.RequestOpts{
 		OkCodes: []int{200, 201, 202},
 	})

--- a/gcore/gpu/v3/images/client.go
+++ b/gcore/gpu/v3/images/client.go
@@ -86,7 +86,7 @@ func (opts UploadVirtualImageOpts) ToImageCreateMap() (map[string]interface{}, e
 }
 
 func (c *ServiceClient) uploadBaremetalURL() string {
-	return c.ServiceURL("baremetal", "images")
+	return c.ServiceURL("images")
 }
 
 func (c *ServiceClient) uploadVirtualURL() string {

--- a/gcore/gpu/v3/images/client.go
+++ b/gcore/gpu/v3/images/client.go
@@ -85,21 +85,14 @@ func (opts UploadVirtualImageOpts) ToImageCreateMap() (map[string]interface{}, e
 	return gcorecloud.BuildRequestBody(opts, "")
 }
 
-func (c *ServiceClient) uploadBaremetalURL() string {
-	return c.ServiceURL("images")
-}
-
-func (c *ServiceClient) uploadVirtualURL() string {
-	return c.ServiceURL("virtual", "images")
-}
-
 func (c *ServiceClient) UploadBaremetalImage(opts UploadBaremetalImageOpts) (*tasks.Task, error) {
+	url := UploadBaremetalURL(c.ServiceClient)
 	b, err := opts.ToImageCreateMap()
 	if err != nil {
 		return nil, err
 	}
 	var result tasks.Task
-	_, err = c.Post(c.uploadBaremetalURL(), b, &result, &gcorecloud.RequestOpts{
+	_, err = c.Post(url, b, &result, &gcorecloud.RequestOpts{
 		OkCodes: []int{200, 201, 202},
 	})
 	if err != nil {
@@ -109,12 +102,13 @@ func (c *ServiceClient) UploadBaremetalImage(opts UploadBaremetalImageOpts) (*ta
 }
 
 func (c *ServiceClient) UploadVirtualImage(opts UploadVirtualImageOpts) (*tasks.Task, error) {
+	url := UploadVirtualURL(c.ServiceClient)
 	b, err := opts.ToImageCreateMap()
 	if err != nil {
 		return nil, err
 	}
 	var result tasks.Task
-	_, err = c.Post(c.uploadVirtualURL(), b, &result, &gcorecloud.RequestOpts{
+	_, err = c.Post(url, b, &result, &gcorecloud.RequestOpts{
 		OkCodes: []int{200, 201, 202},
 	})
 	if err != nil {

--- a/gcore/gpu/v3/images/client.go
+++ b/gcore/gpu/v3/images/client.go
@@ -1,0 +1,124 @@
+package images
+
+import (
+	gcorecloud "github.com/G-Core/gcorelabscloud-go"
+	"github.com/G-Core/gcorelabscloud-go/gcore/task/v1/tasks"
+)
+
+type ServiceClient struct {
+	*gcorecloud.ServiceClient
+}
+
+// UploadBaremetalImageOpts represents options for uploading a baremetal GPU image.
+type UploadBaremetalImageOpts struct {
+	// Image name
+	Name string `json:"name" required:"true"`
+
+	// Image URL
+	URL string `json:"url" required:"true"`
+
+	// Image architecture type: aarch64, x86_64
+	Architecture *string `json:"architecture,omitempty"`
+
+	// When True, image cannot be deleted unless all volumes, created from it, are deleted.
+	CowFormat *bool `json:"cow_format,omitempty"`
+
+	// Specifies the type of firmware with which to boot the guest.
+	HwFirmwareType *ImageHwFirmwareType `json:"hw_firmware_type,omitempty"`
+
+	// Create one or more metadata items for a cluster
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+
+	// OS Distribution, i.e. Debian, CentOS, Ubuntu, CoreOS etc.
+	OsDistro *string `json:"os_distro,omitempty"`
+
+	// The operating system installed on the image.
+	OsType *ImageOsType `json:"os_type,omitempty"`
+
+	// OS version, i.e. 19.04 (for Ubuntu) or 9.4 for Debian
+	OsVersion *string `json:"os_version,omitempty"`
+
+	// Permission to use a ssh key in instances
+	SshKey *SshKeyType `json:"ssh_key,omitempty"`
+}
+
+// UploadVirtualImageOpts represents options for uploading a virtual GPU image.
+type UploadVirtualImageOpts struct {
+	// Image name
+	Name string `json:"name" required:"true"`
+
+	// Image URL
+	URL string `json:"url" required:"true"`
+
+	// Image architecture type: aarch64, x86_64
+	Architecture *string `json:"architecture,omitempty"`
+
+	// When True, image cannot be deleted unless all volumes, created from it, are deleted.
+	CowFormat *bool `json:"cow_format,omitempty"`
+
+	// Specifies the type of firmware with which to boot the guest.
+	HwFirmwareType *ImageHwFirmwareType `json:"hw_firmware_type,omitempty"`
+
+	// Create one or more metadata items for a cluster
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+
+	// OS Distribution, i.e. Debian, CentOS, Ubuntu, CoreOS etc.
+	OsDistro *string `json:"os_distro,omitempty"`
+
+	// The operating system installed on the image.
+	OsType *ImageOsType `json:"os_type,omitempty"`
+
+	// OS version, i.e. 19.04 (for Ubuntu) or 9.4 for Debian
+	OsVersion *string `json:"os_version,omitempty"`
+
+	// Permission to use a ssh key in instances
+	SshKey *SshKeyType `json:"ssh_key,omitempty"`
+}
+
+// ToImageCreateMap builds a request body from UploadBaremetalImageOpts.
+func (opts UploadBaremetalImageOpts) ToImageCreateMap() (map[string]interface{}, error) {
+	return gcorecloud.BuildRequestBody(opts, "")
+}
+
+// ToImageCreateMap builds a request body from UploadVirtualImageOpts.
+func (opts UploadVirtualImageOpts) ToImageCreateMap() (map[string]interface{}, error) {
+	return gcorecloud.BuildRequestBody(opts, "")
+}
+
+func (c *ServiceClient) uploadBaremetalURL() string {
+	return c.ServiceURL("baremetal", "images")
+}
+
+func (c *ServiceClient) uploadVirtualURL() string {
+	return c.ServiceURL("virtual", "images")
+}
+
+func (c *ServiceClient) UploadBaremetalImage(opts UploadBaremetalImageOpts) (*tasks.Task, error) {
+	b, err := opts.ToImageCreateMap()
+	if err != nil {
+		return nil, err
+	}
+	var result tasks.Task
+	_, err = c.Post(c.uploadBaremetalURL(), b, &result, &gcorecloud.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *ServiceClient) UploadVirtualImage(opts UploadVirtualImageOpts) (*tasks.Task, error) {
+	b, err := opts.ToImageCreateMap()
+	if err != nil {
+		return nil, err
+	}
+	var result tasks.Task
+	_, err = c.Post(c.uploadVirtualURL(), b, &result, &gcorecloud.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/gcore/gpu/v3/images/client.go
+++ b/gcore/gpu/v3/images/client.go
@@ -9,8 +9,8 @@ type ServiceClient struct {
 	*gcorecloud.ServiceClient
 }
 
-// UploadBaremetalImageOpts represents options for uploading a baremetal GPU image.
-type UploadBaremetalImageOpts struct {
+// ImageOpts represents common options for uploading GPU images.
+type ImageOpts struct {
 	// Image name
 	Name string `json:"name" required:"true"`
 
@@ -42,55 +42,18 @@ type UploadBaremetalImageOpts struct {
 	SshKey *SshKeyType `json:"ssh_key,omitempty"`
 }
 
-// UploadVirtualImageOpts represents options for uploading a virtual GPU image.
-type UploadVirtualImageOpts struct {
-	// Image name
-	Name string `json:"name" required:"true"`
-
-	// Image URL
-	URL string `json:"url" required:"true"`
-
-	// Image architecture type: aarch64, x86_64
-	Architecture *string `json:"architecture,omitempty"`
-
-	// When True, image cannot be deleted unless all volumes, created from it, are deleted.
-	CowFormat *bool `json:"cow_format,omitempty"`
-
-	// Specifies the type of firmware with which to boot the guest.
-	HwFirmwareType *ImageHwFirmwareType `json:"hw_firmware_type,omitempty"`
-
-	// Create one or more metadata items for a cluster
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
-
-	// OS Distribution, i.e. Debian, CentOS, Ubuntu, CoreOS etc.
-	OsDistro *string `json:"os_distro,omitempty"`
-
-	// The operating system installed on the image.
-	OsType *ImageOsType `json:"os_type,omitempty"`
-
-	// OS version, i.e. 19.04 (for Ubuntu) or 9.4 for Debian
-	OsVersion *string `json:"os_version,omitempty"`
-
-	// Permission to use a ssh key in instances
-	SshKey *SshKeyType `json:"ssh_key,omitempty"`
-}
-
-// ToImageCreateMap builds a request body from UploadBaremetalImageOpts.
-func (opts UploadBaremetalImageOpts) ToImageCreateMap() (map[string]interface{}, error) {
+// ToImageCreateMap builds a request body from ImageOpts.
+func (opts ImageOpts) ToImageCreateMap() (map[string]interface{}, error) {
 	return gcorecloud.BuildRequestBody(opts, "")
 }
 
-// ToImageCreateMap builds a request body from UploadVirtualImageOpts.
-func (opts UploadVirtualImageOpts) ToImageCreateMap() (map[string]interface{}, error) {
-	return gcorecloud.BuildRequestBody(opts, "")
-}
-
-func (c *ServiceClient) UploadBaremetalImage(opts UploadBaremetalImageOpts) (*tasks.TaskResults, error) {
-	url := UploadBaremetalURL(c.ServiceClient)
+func (c *ServiceClient) UploadImage(opts ImageOpts) (*tasks.TaskResults, error) {
+	url := ImageURL(c.ServiceClient)
 	b, err := opts.ToImageCreateMap()
 	if err != nil {
 		return nil, err
 	}
+
 	var result tasks.TaskResults
 	_, err = c.Post(url, b, &result, &gcorecloud.RequestOpts{
 		OkCodes: []int{200, 201, 202},
@@ -101,18 +64,7 @@ func (c *ServiceClient) UploadBaremetalImage(opts UploadBaremetalImageOpts) (*ta
 	return &result, nil
 }
 
-func (c *ServiceClient) UploadVirtualImage(opts UploadVirtualImageOpts) (*tasks.TaskResults, error) {
-	url := UploadVirtualURL(c.ServiceClient)
-	b, err := opts.ToImageCreateMap()
-	if err != nil {
-		return nil, err
-	}
-	var result tasks.TaskResults
-	_, err = c.Post(url, b, &result, &gcorecloud.RequestOpts{
-		OkCodes: []int{200, 201, 202},
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &result, nil
+// NewImageOpts creates a new ImageOpts instance
+func NewImageOpts() ImageOpts {
+	return ImageOpts{}
 }

--- a/gcore/gpu/v3/images/results.go
+++ b/gcore/gpu/v3/images/results.go
@@ -1,0 +1,132 @@
+package images
+
+import (
+	"fmt"
+
+	gcorecloud "github.com/G-Core/gcorelabscloud-go"
+	"github.com/G-Core/gcorelabscloud-go/gcore/task/v1/tasks"
+	"github.com/G-Core/gcorelabscloud-go/pagination"
+)
+
+type ImageHwFirmwareType string
+type ImageOsType string
+type SshKeyType string
+
+const (
+	HwFirmwareTypeBios ImageHwFirmwareType = "bios"
+	HwFirmwareTypeUefi ImageHwFirmwareType = "uefi"
+
+	OsTypeLinux   ImageOsType = "linux"
+	OsTypeWindows ImageOsType = "windows"
+
+	SshKeyAllow    SshKeyType = "allow"
+	SshKeyDeny     SshKeyType = "deny"
+	SshKeyRequired SshKeyType = "required"
+)
+
+type commonResult struct {
+	gcorecloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a image resource.
+func (r commonResult) Extract() (*Image, error) {
+	var s Image
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "")
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Image.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Image.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of a update operation. Call its Extract
+// method to interpret it as a Image.
+type UpdateResult struct {
+	commonResult
+}
+
+type Image struct {
+	ID             string                   `json:"id"`
+	Name           string                   `json:"name"`
+	Status         string                   `json:"status"`
+	Architecture   string                   `json:"architecture"`
+	CowFormat      bool                     `json:"cow_format"`
+	HwFirmwareType *ImageHwFirmwareType     `json:"hw_firmware_type"`
+	OsDistro       *string                  `json:"os_distro"`
+	OsType         *ImageOsType             `json:"os_type"`
+	OsVersion      *string                  `json:"os_version"`
+	SshKey         SshKeyType               `json:"ssh_key"`
+	URL            string                   `json:"url"`
+	CreatedAt      gcorecloud.JSONRFC3339Z  `json:"created_at"`
+	UpdatedAt      *gcorecloud.JSONRFC3339Z `json:"updated_at"`
+	CreatorTaskID  *string                  `json:"creator_task_id"`
+	TaskID         *string                  `json:"task_id"`
+	Metadata       map[string]interface{}   `json:"metadata"`
+}
+
+// ImagePage is the page returned by a pager when traversing over a
+// collection of images.
+type ImagePage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of images has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r ImagePage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gcorecloud.Link `json:"links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gcorecloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a ImagePage struct is empty.
+func (r ImagePage) IsEmpty() (bool, error) {
+	is, err := ExtractImages(r)
+	return len(is) == 0, err
+}
+
+// ExtractImages accepts a Page struct, specifically a ImagePage struct,
+// and extracts the elements into a slice of image structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractImages(r pagination.Page) ([]Image, error) {
+	var s []Image
+	err := ExtractImagesInto(r, &s)
+	return s, err
+}
+
+func ExtractImagesInto(r pagination.Page, v interface{}) error {
+	return r.(ImagePage).Result.ExtractIntoSlicePtr(v, "results")
+}
+
+type ImageTaskResult struct {
+	Images []string `json:"images"`
+}
+
+func ExtractImageIDFromTask(task *tasks.Task) (string, error) {
+	var result ImageTaskResult
+	err := gcorecloud.NativeMapToStruct(task.CreatedResources, &result)
+	if err != nil {
+		return "", fmt.Errorf("cannot decode image information in task structure: %w", err)
+	}
+	if len(result.Images) == 0 {
+		return "", fmt.Errorf("cannot decode image information in task structure: %w", err)
+	}
+	return result.Images[0], nil
+}

--- a/gcore/gpu/v3/images/service_client.go
+++ b/gcore/gpu/v3/images/service_client.go
@@ -1,0 +1,12 @@
+package images
+
+import (
+	gcorecloud "github.com/G-Core/gcorelabscloud-go"
+	"github.com/G-Core/gcorelabscloud-go/client/common"
+	"github.com/urfave/cli/v2"
+)
+
+// NewGPUImageClientV3 creates a new GPU image client
+func NewGPUImageClientV3(c *cli.Context) (*gcorecloud.ServiceClient, error) {
+	return common.BuildClient(c, "gpu/images", "v3")
+}

--- a/gcore/gpu/v3/images/testing/fixtures.go
+++ b/gcore/gpu/v3/images/testing/fixtures.go
@@ -1,0 +1,29 @@
+package testing
+
+import (
+	"github.com/G-Core/gcorelabscloud-go/gcore/task/v1/tasks"
+)
+
+const TokenID = "token_id"
+
+var (
+	TestUploadBaremetalImageResponse = `
+{
+    "id": "50f53a35-42ed-40c4-82b2-5a37fb3e00bc",
+    "state": "NEW",
+    "task_type": "upload_baremetal_image"
+}`
+
+	TestUploadVirtualImageResponse = `
+{
+    "id": "50f53a35-42ed-40c4-82b2-5a37fb3e00bc",
+    "state": "NEW",
+    "task_type": "upload_virtual_image"
+}`
+
+	ExpectedTaskResults = &tasks.Task{
+		ID:       "50f53a35-42ed-40c4-82b2-5a37fb3e00bc",
+		State:    tasks.TaskStateNew,
+		TaskType: "upload_baremetal_image",
+	}
+)

--- a/gcore/gpu/v3/images/testing/requests_test.go
+++ b/gcore/gpu/v3/images/testing/requests_test.go
@@ -1,0 +1,141 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/G-Core/gcorelabscloud-go/gcore/gpu/v3/images"
+	th "github.com/G-Core/gcorelabscloud-go/testhelper"
+	thclient "github.com/G-Core/gcorelabscloud-go/testhelper/client"
+)
+
+func TestUploadBaremetalImage(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc(fmt.Sprintf("/v3/gpu/baremetal/%d/%d/images", thclient.ProjectID, thclient.RegionID), func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", thclient.TokenID))
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `{
+			"url": "http://example.com/image.img",
+			"name": "test-image",
+			"ssh_key": "allow",
+			"cow_format": true,
+			"architecture": "x86_64",
+			"os_distro": "ubuntu",
+			"os_type": "linux",
+			"os_version": "20.04",
+			"hw_firmware_type": "bios",
+			"metadata": {
+				"key": "value"
+			}
+		}`)
+
+		w.WriteHeader(http.StatusOK)
+		_, err := fmt.Fprint(w, TestUploadBaremetalImageResponse)
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	sshKey := images.SshKeyAllow
+	cowFormat := true
+	arch := "x86_64"
+	osType := images.OsTypeLinux
+	hwType := images.HwFirmwareTypeBios
+
+	opts := images.UploadBaremetalImageOpts{
+		URL:            "http://example.com/image.img",
+		Name:           "test-image",
+		SshKey:         &sshKey,
+		CowFormat:      &cowFormat,
+		Architecture:   &arch,
+		OsDistro:       stringPtr("ubuntu"),
+		OsType:         &osType,
+		OsVersion:      stringPtr("20.04"),
+		HwFirmwareType: &hwType,
+		Metadata: map[string]interface{}{
+			"key": "value",
+		},
+	}
+
+	sc := &images.ServiceClient{
+		ServiceClient: thclient.ServiceClient(),
+	}
+	taskResults, err := sc.UploadBaremetalImage(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	th.AssertDeepEquals(t, ExpectedTaskResults, taskResults)
+}
+
+func TestUploadVirtualImage(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc(fmt.Sprintf("/v3/gpu/virtual/%d/%d/images", thclient.ProjectID, thclient.RegionID), func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", thclient.TokenID))
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `{
+			"url": "http://example.com/image.img",
+			"name": "test-image",
+			"ssh_key": "allow",
+			"cow_format": true,
+			"architecture": "x86_64",
+			"os_distro": "ubuntu",
+			"os_type": "linux",
+			"os_version": "20.04",
+			"hw_firmware_type": "bios",
+			"metadata": {
+				"key": "value"
+			}
+		}`)
+
+		w.WriteHeader(http.StatusOK)
+		_, err := fmt.Fprint(w, TestUploadVirtualImageResponse)
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	sshKey := images.SshKeyAllow
+	cowFormat := true
+	arch := "x86_64"
+	osType := images.OsTypeLinux
+	hwType := images.HwFirmwareTypeBios
+
+	opts := images.UploadVirtualImageOpts{
+		URL:            "http://example.com/image.img",
+		Name:           "test-image",
+		SshKey:         &sshKey,
+		CowFormat:      &cowFormat,
+		Architecture:   &arch,
+		OsDistro:       stringPtr("ubuntu"),
+		OsType:         &osType,
+		OsVersion:      stringPtr("20.04"),
+		HwFirmwareType: &hwType,
+		Metadata: map[string]interface{}{
+			"key": "value",
+		},
+	}
+
+	sc := &images.ServiceClient{
+		ServiceClient: thclient.ServiceClient(),
+	}
+	taskResults, err := sc.UploadVirtualImage(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	th.AssertDeepEquals(t, ExpectedTaskResults, taskResults)
+}
+
+func stringPtr(s string) *string {
+	return &s
+}

--- a/gcore/gpu/v3/images/urls.go
+++ b/gcore/gpu/v3/images/urls.go
@@ -10,11 +10,6 @@ const (
 )
 
 // UploadBaremetalURL returns URL for uploading baremetal GPU images
-func UploadBaremetalURL(c *gcorecloud.ServiceClient) string {
-	return c.ServiceURL(imagesPath)
-}
-
-// UploadVirtualURL returns URL for uploading virtual GPU images
-func UploadVirtualURL(c *gcorecloud.ServiceClient) string {
+func ImageURL(c *gcorecloud.ServiceClient) string {
 	return c.ServiceURL(imagesPath)
 }

--- a/gcore/gpu/v3/images/urls.go
+++ b/gcore/gpu/v3/images/urls.go
@@ -1,20 +1,20 @@
 package images
 
 import (
-	"fmt"
+	gcorecloud "github.com/G-Core/gcorelabscloud-go"
 )
 
-// resourcePath is a base path for GPU image endpoints
-func resourcePath(projectID, regionID int) string {
-	return fmt.Sprintf("/v3/gpu/%d/%d", projectID, regionID)
+// Common path components
+const (
+	imagesPath = "images"
+)
+
+// UploadBaremetalURL returns URL for uploading baremetal GPU images
+func UploadBaremetalURL(c *gcorecloud.ServiceClient) string {
+	return c.ServiceURL(imagesPath)
 }
 
-// uploadBaremetalURL returns URL for uploading baremetal GPU images
-func uploadBaremetalURL(projectID, regionID int) string {
-	return resourcePath(projectID, regionID) + "/baremetal/images"
-}
-
-// uploadVirtualURL returns URL for uploading virtual GPU images
-func uploadVirtualURL(projectID, regionID int) string {
-	return resourcePath(projectID, regionID) + "/virtual/images"
+// UploadVirtualURL returns URL for uploading virtual GPU images
+func UploadVirtualURL(c *gcorecloud.ServiceClient) string {
+	return c.ServiceURL(imagesPath)
 }

--- a/gcore/gpu/v3/images/urls.go
+++ b/gcore/gpu/v3/images/urls.go
@@ -1,0 +1,20 @@
+package images
+
+import (
+	"fmt"
+)
+
+// resourcePath is a base path for GPU image endpoints
+func resourcePath(projectID, regionID int) string {
+	return fmt.Sprintf("/v3/gpu/%d/%d", projectID, regionID)
+}
+
+// uploadBaremetalURL returns URL for uploading baremetal GPU images
+func uploadBaremetalURL(projectID, regionID int) string {
+	return resourcePath(projectID, regionID) + "/baremetal/images"
+}
+
+// uploadVirtualURL returns URL for uploading virtual GPU images
+func uploadVirtualURL(projectID, regionID int) string {
+	return resourcePath(projectID, regionID) + "/virtual/images"
+}


### PR DESCRIPTION
Implement GPU image upload functionality for both baremetal and virtual GPU images, including:
- Client and service client for GPU image operations
- CLI commands for uploading images
- Comprehensive options for image metadata and configuration
- Integration with existing command structure

This adds support for uploading GPU images with various configuration options such as architecture, OS type, firmware type, and metadata.