### PR TITLE
GCLOUD2-17734 Refactor resize cmd to target AI GPU endpoint

### DIFF
--- a/gcore/ai/v1/ais/requests.go
+++ b/gcore/ai/v1/ais/requests.go
@@ -78,32 +78,23 @@ func (opts CreateOpts) ToAIClusterCreateMap() (map[string]interface{}, error) {
 	return mp, nil
 }
 
-// ResizeAIClusterOptsBuilder builds parameters or change flavor request.
-type ResizeAIClusterOptsBuilder interface {
-	ToResizeAIClusterActionMap() (map[string]interface{}, error)
+// ResizeGPUAIClusterOptsBuilder builds parameters or change flavor request.
+type ResizeGPUAIClusterOptsBuilder interface {
+	ToResizeGPUAIClusterActionMap() (map[string]interface{}, error)
 }
 
-// ResizeAIClusterOpts represents options used to resize AI Clsuter.
-type ResizeAIClusterOpts struct {
-	Flavor         string                                  `json:"flavor" validate:"omitempty,min=1"`
-	ImageID        string                                  `json:"image_id" validate:"omitempty,uuid4"`
-	Interfaces     []instances.InterfaceInstanceCreateOpts `json:"interfaces" validate:"required,dive"`
-	Volumes        []instances.CreateVolumeOpts            `json:"volumes,omitempty" validate:"omitempty,dive"`
-	SecurityGroups []gcorecloud.ItemID                     `json:"security_groups,omitempty" validate:"omitempty,dive,uuid4"`
-	Keypair        string                                  `json:"keypair_name,omitempty"`
-	Password       string                                  `json:"password" validate:"omitempty,required_with=Username"`
-	Username       string                                  `json:"username" validate:"omitempty,required_with=Password"`
-	UserData       string                                  `json:"user_data,omitempty" validate:"omitempty,base64"`
-	Metadata       map[string]string                       `json:"metadata,omitempty" validate:"omitempty,dive"`
+// ResizeGPUAIClusterOpts represents options used to resize GPU AI Cluster.
+type ResizeGPUAIClusterOpts struct {
+	InstancesCount int `json:"instances_count" validate:"required"`
 }
 
 // Validate
-func (opts ResizeAIClusterOpts) Validate() error {
+func (opts ResizeGPUAIClusterOpts) Validate() error {
 	return gcorecloud.ValidateStruct(opts)
 }
 
-// ToResizeAIClusterActionMap builds a request body from ResizeAIClusterOpts.
-func (opts ResizeAIClusterOpts) ToResizeAIClusterActionMap() (map[string]interface{}, error) {
+// ToResizeGPUAIClusterActionMap builds a request body from ResizeGPUAIClusterOpts.
+func (opts ResizeGPUAIClusterOpts) ToResizeGPUAIClusterActionMap() (map[string]interface{}, error) {
 	if err := opts.Validate(); err != nil {
 		return nil, err
 	}
@@ -352,8 +343,8 @@ func Resume(client *gcorecloud.ServiceClient, id string) (r tasks.Result) {
 }
 
 // Resize AI Cluster.
-func Resize(client *gcorecloud.ServiceClient, id string, opts ResizeAIClusterOptsBuilder) (r tasks.Result) {
-	b, err := opts.ToResizeAIClusterActionMap()
+func Resize(client *gcorecloud.ServiceClient, id string, opts ResizeGPUAIClusterOptsBuilder) (r tasks.Result) {
+	b, err := opts.ToResizeGPUAIClusterActionMap()
 	if err != nil {
 		r.Err = err
 		return

--- a/gcore/ai/v1/ais/testing/fixtures.go
+++ b/gcore/ai/v1/ais/testing/fixtures.go
@@ -547,26 +547,8 @@ const CreateRequest = `
 
 const ResizeRequest = `
 {
-  "flavor": "g2a-ai-fake-v1pod-8",
-  "image_id": "06e62653-1f88-4d38-9aa6-62833e812b4f",
-  "interfaces": [
-      {
-          "network_id": "518ba531-496b-4676-8ea4-68e2ed3b2e4b",
-          "type": "any_subnet"
-      }
-  ],
-  "username": "useruser",
-  "password": "secret",
-  "volumes": [
-      {
-          "boot_index": 0,
-          "image_id": "06e62653-1f88-4d38-9aa6-62833e812b4f",
-          "size": 20,                                                                                                                                                                                                                                     
-          "source": "image",                                                                                                                                                                                                                               
-          "type_name": "standard"                                                                                                                                                                                                                        
-      }                                                                                                                                                                                                                                                    
-  ]
-}       
+  "instances_count": 2
+}
 `
 
 const PortsListResponse = `

--- a/gcore/ai/v1/ais/testing/requests_test.go
+++ b/gcore/ai/v1/ais/testing/requests_test.go
@@ -27,6 +27,10 @@ func prepareGetActionTestURLParams(version string, id string, action string) str
 	return fmt.Sprintf("/%s/ai/clusters/%d/%d/%s/%s", version, fake.ProjectID, fake.RegionID, id, action)
 }
 
+func prepareGetActionGPUTestURLParams(version string, id string, action string) string { // nolint
+	return fmt.Sprintf("/%s/ai/clusters/gpu/%d/%d/%s/%s", version, fake.ProjectID, fake.RegionID, id, action)
+}
+
 func prepareListTestURL() string {
 	return prepareListTestURLParams("v1", fake.ProjectID, fake.RegionID)
 }
@@ -83,7 +87,7 @@ func prepareResumeTestURL(id string) string {
 }
 
 func prepareResizeTestURL(id string) string {
-	return prepareGetActionTestURLParams("v1", id, "resize")
+	return prepareGetActionGPUTestURLParams("v1", id, "resize")
 }
 
 func prepareGetTestURL(id string) string {
@@ -390,32 +394,12 @@ func TestResize(t *testing.T) {
 		}
 	})
 
-	options := ai.ResizeAIClusterOpts{
-		Flavor:  "g2a-ai-fake-v1pod-8",
-		ImageID: "06e62653-1f88-4d38-9aa6-62833e812b4f",
-		Volumes: []instances.CreateVolumeOpts{
-			{
-				Source:    types.Image,
-				BootIndex: 0,
-				Size:      20,
-				TypeName:  volumes.Standard,
-				ImageID:   "06e62653-1f88-4d38-9aa6-62833e812b4f",
-			},
-		},
-		Interfaces: []instances.InterfaceInstanceCreateOpts{
-			{
-				InterfaceOpts: instances.InterfaceOpts{
-					Type:      types.AnySubnetInterfaceType,
-					NetworkID: "518ba531-496b-4676-8ea4-68e2ed3b2e4b",
-				},
-			},
-		},
-		Password: "secret",
-		Username: "useruser",
+	options := ai.ResizeGPUAIClusterOpts{
+		InstancesCount: 2,
 	}
 	err := options.Validate()
 	require.NoError(t, err)
-	client := fake.ServiceTokenClient("ai/clusters", "v1")
+	client := fake.ServiceTokenClient("ai/clusters/gpu", "v1")
 	tasks, err := ai.Resize(client, AICluster1.ClusterID, options).Extract()
 	require.NoError(t, err)
 	require.Equal(t, Tasks1, *tasks)


### PR DESCRIPTION
Refactor the `resize` command to send requests to the [AIClustersGPUResize](https://api.gcore.com/docs/cloud#tag/GPU-Cloud/operation/AIClustersGPUResizeHandler.post) endpoint, instead of the legacy AIClustersResize endpoint.

New usage of the command:
```bash
gcoreclient ai resize --instances-count 2 "<CLUSTER_ID"
```

