### PR TITLE
Upload build artifacts into workflow runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [ master, main, test-artifacts-upload ]
   pull_request:
     branches: [ master, main ]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,4 +24,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: gcoreclient
-          path: gcoreclient
+          path: ./gcoreclient

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
           go-version: 1.21
 
       - name: Build
-        run: go build -v ./...
+        run: make build
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: gcoreclient
-          path: ./gcoreclient
+          path: gcoreclient

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,15 @@ jobs:
         with:
           go-version: 1.21
 
-      - name: Build
-        run: make build
+      - name: Build darwin/arm64
+        run: make build-with-dist GOOS=darwin GOARCH=arm64
+
+      - name: Build windows/amd64
+        run: make build-with-dist GOOS=windows GOARCH=amd64
 
       - name: Upload Artifact
+        # if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: gcoreclient
-          path: gcoreclient
+          path: gcoreclient*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 
 on:
   push:
-    branches: [ master, main, test-artifacts-upload ]
+    branches: [ master, main ]
   pull_request:
     branches: [ master, main ]
 
@@ -24,7 +24,6 @@ jobs:
         run: make build-with-dist GOOS=windows GOARCH=amd64
 
       - name: Upload Artifact
-        # if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: gcoreclient

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,3 +19,9 @@ jobs:
 
       - name: Build
         run: go build -v ./...
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gcoreclient
+          path: gcoreclient

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,12 @@ build:
 	-o $(BINARY) \
 	$(CMD_PACKAGE)
 
+build-with-dist:
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build \
+	-ldflags $(LDFLAGS) \
+	-o $(BINARY)-$(GOOS)-$(GOARCH) \
+	$(CMD_PACKAGE)
+
 install:
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go install \
 	-ldflags $(LDFLAGS) \


### PR DESCRIPTION
This PR performs the following changes:
- Adds a new Makefile target `build-with-dist` that performs the build and appends the output binary's name with the distribution information (e.g. `gcoreclient-windows-amd64`).
- Change the **build** work  such that it builds the binaries for `darwin/arm64` and `windows/amd64`, and uploads them as build artifacts into `.zip` file.

Why this change is needed? to provide pre-built binaries for testing purposes before the PR is merged.