### PR TITLE
GCLOUD2-17736 Add support for deleting a node from a GPU cluster

### DIFF
--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -247,6 +247,15 @@ func GetFirstStringArg(c *cli.Context, errorText string) (string, error) {
 	return arg, nil
 }
 
+// GetNthStringArg returns the nth string argument, or an error if the arg is blank
+func GetNthStringArg(c *cli.Context, errorText string, n int) (string, error) {
+	arg := c.Args().Get(n)
+	if arg == "" {
+		return "", cli.Exit(fmt.Errorf(errorText), 1)
+	}
+	return arg, nil
+}
+
 func GetFirstIntArg(c *cli.Context, errorText string) (int, error) {
 	arg := c.Args().First()
 	if arg == "" {

--- a/gcore/ai/v1/ais/urls.go
+++ b/gcore/ai/v1/ais/urls.go
@@ -105,3 +105,7 @@ func metadataItemURL(c *gcorecloud.ServiceClient, id string, key string) string 
 func rebuildGPUAIURL(c *gcorecloud.ServiceClient, clusterID string) string {
 	return c.ServiceURL(clusterID, "rebuild")
 }
+
+func nodeFromGPUClusterURL(c *gcorecloud.ServiceClient, clusterID, instanceID string) string {
+	return c.ServiceURL(clusterID, "node", instanceID)
+}


### PR DESCRIPTION
This PR allows deleting a node from an existing GPU cluster. The following changes were made:
- new SDK function `DeleteNodeFromGPUCluster` for deleting a node from a GPU cluster
- new CLI subcommand `delete-node` that performs the same operation.

Example command:
```bash
gcoreclient ai delete-node <cluster_id> <instance_id>
``` 

Sample output:
```
{
  "tasks": [
    "542888dc-04ed-4a0b-bd90-66944ecbfad7"
  ]
}
```

The respective API endpoint can be found [here](https://api.gcore.com/docs/cloud#tag/GPU-Cloud/operation/AIClustersNodeDelete.delete).
