### PR TITLE
Add step to release pipeline to check that tag version matches AppVersion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,15 @@ jobs:
         with:
           go-version: 1.21
       -
+        name: Check tag version against AppVersion
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/}
+          APP_VERSION=$(grep -oP 'var AppVersion = "\K[0-9]+\.[0-9]+\.[0-9]+' provider_client.go)
+          if [ "$TAG_VERSION" != "$APP_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match AppVersion ($APP_VERSION)"
+            exit 1
+          fi
+      -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           TAG_VERSION=${GITHUB_REF#refs/tags/}
           APP_VERSION=$(grep -oP 'var AppVersion = "\K[0-9]+\.[0-9]+\.[0-9]+' provider_client.go)
-          if [ "$TAG_VERSION" != "$APP_VERSION" ]; then
+          if [ "$TAG_VERSION" != "v$APP_VERSION" ]; then
             echo "Tag version ($TAG_VERSION) does not match AppVersion ($APP_VERSION)"
             exit 1
           fi


### PR DESCRIPTION
Currently, developers manage the `AppVersion` manually, and before each new release, it needs to be updated. This PR adds a step to the **release** workflow that compares the git tag version, associated with this new release, with the `AppVersion` specified in the code. If the versions don't match, the pipeline fails, and the release doesn't succeed.

The goal is to make sure the versions match and to force the developer making a release to bump the `AppVersion` before making the release.

The `AppVersion` is located in [provider_client.go#L23](https://github.com/G-Core/gcorelabscloud-go/blob/2dfeed362704125ad8392d69f1f880cee4e9000e/provider_client.go#L23).