### PR TITLE
Append the commit id to the build upload artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,11 @@ jobs:
         run: make build-with-dist GOOS=windows GOARCH=amd64
 
       - name: Set truncated SHA
-        id: vars
-        run: echo "::set-output name=short_sha::${GITHUB_SHA::8}"
+        id: truncated_sha
+        run: echo "github_short_sha=${GITHUB_SHA::8}" >> "${GITHUB_OUTPUT}"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: gcoreclient-${{ steps.vars.outputs.short_sha }}
+          name: gcoreclient-${{ steps.truncated_sha.github_short_sha }}
           path: gcoreclient*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,9 @@ jobs:
 
       - name: Set truncated SHA
         id: truncated_sha
-        run: echo "github_short_sha=${GITHUB_SHA::8}" >> "${GITHUB_OUTPUT}"
+        run: |
+          echo "GITHUB_SHA=${{ github.sha }}"
+          echo "github_short_sha=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,10 @@ jobs:
       - name: Set truncated SHA
         id: truncated_sha
         run: |
-          echo "GITHUB_SHA=${{ github.sha }}"
+          GITHUB_SHA=${{ github.sha }}
+          echo "GITHUB_SHA is $GITHUB_SHA"
           echo "github_short_sha=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
+          echo "github_short_sha is ${GITHUB_SHA::8}"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,16 +23,11 @@ jobs:
       - name: Build windows/amd64
         run: make build-with-dist GOOS=windows GOARCH=amd64
 
-      - name: Set truncated SHA
-        id: truncated_sha
-        run: |
-          GITHUB_SHA=${{ github.sha }}
-          echo "GITHUB_SHA is $GITHUB_SHA"
-          echo "github_short_sha=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
-          echo "github_short_sha is ${GITHUB_SHA::8}"
+      - name: Set truncated SHA as environment variable
+        run: echo "SHORT_SHA=${GITHUB_SHA::8}" >> $GITHUB_ENV
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: gcoreclient-${{ steps.truncated_sha.github_short_sha }}
+          name: gcoreclient-${{ env.SHORT_SHA }}
           path: gcoreclient*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,5 +26,5 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: gcoreclient
+          name: gcoreclient-${{ github.sha }}
           path: gcoreclient*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,12 @@ jobs:
       - name: Build windows/amd64
         run: make build-with-dist GOOS=windows GOARCH=amd64
 
+      - name: Set truncated SHA
+        id: vars
+        run: echo "::set-output name=short_sha::${GITHUB_SHA::8}"
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: gcoreclient-${{ github.sha }}
+          name: gcoreclient-${{ steps.vars.outputs.short_sha }}
           path: gcoreclient*


### PR DESCRIPTION
Appending the commit ID to the name of the binary allows the distinction between builds.