### PR TITLE
Add instances count argument to GPU cluster creation

### DIFF
--- a/client/ais/v1/ais/ias.go
+++ b/client/ais/v1/ais/ias.go
@@ -105,16 +105,23 @@ var aiClusterRebuildCommand = cli.Command{
 			return cli.NewExitError(err, 1)
 		}
 
+		clusterClientV2, err := client2.NewAIClusterClientV2(c)
+		if err != nil {
+			_ = cli.ShowAppHelp(c)
+			return cli.Exit(err, 1)
+		}
+
 		return utils.WaitTaskAndShowResult(c, taskClient, results, c.Bool("d"), func(task tasks.TaskID) (interface{}, error) {
 			taskInfo, err := tasks.Get(taskClient, string(task)).Extract()
 			if err != nil {
 				return nil, fmt.Errorf("cannot get task with ID: %s. Error: %w", task, err)
 			}
-			clusterID, err := ai.ExtractAIClusterIDFromTask(taskInfo)
-			if err != nil {
-				return nil, fmt.Errorf("cannot retrieve AI cluster ID from task info: %w", err)
+			// on rebuild Task the cluster_id is inside the 'data' section
+			clusterID, ok := (*taskInfo.Data)["cluster_id"]
+			if !ok {
+				return nil, fmt.Errorf("cannot get cluster_id from task data section: %+v", taskInfo.Data)
 			}
-			cluster, err := ai.Get(client, clusterID).Extract()
+			cluster, err := ai.Get(clusterClientV2, clusterID.(string)).Extract()
 			if err != nil {
 				return nil, fmt.Errorf("cannot get AI cluster with ID: %s. Error: %w", clusterID, err)
 			}
@@ -733,10 +740,8 @@ var aiClusterCreateCommand = cli.Command{
 			if err != nil {
 				return nil, fmt.Errorf("cannot get task with ID: %s. Error: %w", task, err)
 			}
-			clusterID, err := ai.ExtractAIClusterIDFromTask(taskInfo)
-			if err != nil {
-				return nil, fmt.Errorf("cannot retrieve AI cluster ID from task info: %w", err)
-			}
+			// on create cluster, the cluster_id is the same as the Task id
+			clusterID := taskInfo.ID
 			cluster, err := ai.Get(clusterClientV2, clusterID).Extract()
 			if err != nil {
 				return nil, fmt.Errorf("cannot get AI cluster with ID: %s. Error: %w", clusterID, err)

--- a/client/ais/v1/ais/ias.go
+++ b/client/ais/v1/ais/ias.go
@@ -642,6 +642,12 @@ var aiClusterCreateCommand = cli.Command{
 			Usage:    "create gpu cluster else not gpu cluster",
 			Required: false,
 		},
+		&cli.IntFlag{
+			Name:     "instances-count",
+			Usage:    "number of instances to create",
+			Required: false,
+			Value:    1,
+		},
 	}, flags.WaitCommandFlags...),
 	Action: func(c *cli.Context) error {
 		clusterClient, err := client.NewAIClusterClientV1(c)
@@ -655,6 +661,9 @@ var aiClusterCreateCommand = cli.Command{
 				_ = cli.ShowAppHelp(c)
 				return cli.NewExitError(err, 1)
 			}
+		}
+		if c.Int("instances-count") < 1 {
+			return cli.Exit("instances-count must be greater or equal than 1", 1)
 		}
 
 		clusterClientV2, err := client2.NewAIClusterClientV2(c)
@@ -702,6 +711,7 @@ var aiClusterCreateCommand = cli.Command{
 			Username:       c.String("username"),
 			UserData:       userData,
 			Metadata:       metadata,
+			InstancesCount: c.Int("instances-count"),
 		}
 
 		err = gcorecloud.TranslateValidationError(opts.Validate())

--- a/gcore/ai/v1/ais/requests.go
+++ b/gcore/ai/v1/ais/requests.go
@@ -58,6 +58,7 @@ type CreateOpts struct {
 	Username       string                                  `json:"username" validate:"omitempty,required_with=Password"`
 	UserData       string                                  `json:"user_data,omitempty" validate:"omitempty,base64"`
 	Metadata       map[string]string                       `json:"metadata,omitempty" validate:"omitempty,dive"`
+	InstancesCount int                                     `json:"instances_count,omitempty" validate:"omitempty,min=1"`
 }
 
 // Validate


### PR DESCRIPTION
This PR adds the ability to create GPU clusters with more than one instance, which is the default. The following changes were made:
- new CLI option `instances-count` for specifying the desired number of instances, if not provided the default value of 1 will be used.
- new `InstancesCount` field in the `CreateOpts` struct of the SDK for allowing one to create a cluster with more than one instance using the SDK.

Why this change is needed?
1. Provide users with the ability to create a cluster with multiple instances.
2. Allow the cluster resize operation in the [terraform-provider-gcore](https://github.com/G-Core/terraform-provider-gcorel).

The API endpoint for this operation can be found [here](https://api.gcore.com/docs/cloud#tag/GPU-Cloud/operation/AIClustersGPUHandler.post). The API already supports this field.

How to test:
```bash
gcoreclient ai create \
  --name "create-multiple-instance-cluster" \
  --flavor "<flavor_name>" \
  --image "<image_id>" \
  --keypair "<ssh_keypair_name>" \
  --interface-type "external" \
  --volume-source "image" \
  --volume-size 10167386112 \
  --volume-image-id "<image_id>" \
  --gpu \
  --instances-count 2
```

--- 

This PR also fixes the cluster creation/rebuild output (cluster info not shown) when the Task is terminated. This was only noticeable when running the `create` or `rebuild` commands using the `-w` option.
