### PR TITLE
GCLOUD2-17888 Add ability to List tasks with filter options

### DIFF
--- a/client/tasks/v1/tasks/tasks.go
+++ b/client/tasks/v1/tasks/tasks.go
@@ -21,15 +21,15 @@ var taskListCommand = cli.Command{
 		client, err := client.NewTaskClientV1(c)
 		if err != nil {
 			_ = cli.ShowAppHelp(c)
-			return cli.NewExitError(err, 1)
+			return cli.Exit(err, 1)
 		}
-		pages, err := tasks.List(client).AllPages()
+		pages, err := tasks.ListActive(client).AllPages()
 		if err != nil {
-			return cli.NewExitError(err, 1)
+			return cli.Exit(err, 1)
 		}
 		results, err := tasks.ExtractTasks(pages)
 		if len(results) == 0 {
-			return cli.NewExitError(err, 1)
+			return cli.Exit("No tasks found", 1)
 		}
 		utils.ShowResults(results, c.String("format"))
 		return nil

--- a/gcore/task/v1/tasks/requests.go
+++ b/gcore/task/v1/tasks/requests.go
@@ -55,7 +55,7 @@ func (opts ListOpts) isValid() error {
 // ToTaskListQuery formats a ListOpts into a query string.
 func (opts ListOpts) ToTaskListQuery() (string, error) {
 	if err := gcorecloud.TranslateValidationError(opts.isValid()); err != nil {
-		return "", fmt.Errorf(`invalid task list filter params: "%s"`, opts)
+		return "", fmt.Errorf(`invalid task list filter params: %w`, err)
 	}
 
 	q, err := gcorecloud.BuildQueryString(opts)

--- a/gcore/task/v1/tasks/requests.go
+++ b/gcore/task/v1/tasks/requests.go
@@ -1,18 +1,94 @@
 package tasks
 
 import (
+	"fmt"
 	gcorecloud "github.com/G-Core/gcorelabscloud-go"
 	"github.com/G-Core/gcorelabscloud-go/pagination"
+	"time"
 )
+
+// ListOptsBuilder allows extensions to add additional parameters to the List request.
+type ListOptsBuilder interface {
+	ToTaskListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting List API response.
+type ListOpts struct {
+	ProjectID     *int       `q:"project_id"`
+	State         *TaskState `q:"state"`
+	TaskType      *string    `q:"task_type"`
+	Sorting       *string    `q:"sorting"`
+	FromTimestamp *string    `q:"from_timestamp"`
+}
+
+// isValid validation for Task options.
+func (opts ListOpts) isValid() error {
+	if opts.State != nil {
+		switch TaskState(*opts.State) {
+		case TaskStateError, TaskStateFinished, TaskStateNew, TaskStateRunning:
+			fallthrough
+		default:
+			return fmt.Errorf(`invalid task type: "%s"`, opts.TaskType)
+		}
+	}
+
+	if opts.Sorting != nil {
+		switch *opts.Sorting {
+		case TaskSortingOldFirst, TaskSortingToNewFirst:
+			fallthrough
+		default:
+			return fmt.Errorf(`invalid task sort option: "%s"`, opts.Sorting)
+		}
+	}
+
+	if opts.FromTimestamp != nil {
+		_, err := time.Parse(time.RFC3339, *opts.FromTimestamp)
+		if err != nil {
+			return fmt.Errorf(`timestamp "%s" should be ISO format string`, opts.FromTimestamp)
+		}
+	}
+
+	return nil
+}
+
+// ToTaskListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToTaskListQuery() (string, error) {
+	if err := opts.isValid(); err != nil {
+		return "", fmt.Errorf(`invalid task list filter params: "%s"`, opts)
+	}
+
+	q, err := gcorecloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
 
 // List returns a Pager which allows you to iterate over a collection of
 // cluster templates. It accepts a ListOpts struct, which allows you to filter and sort
 // the returned collection for greater efficiency.
-func List(c *gcorecloud.ServiceClient) pagination.Pager {
+func List(c *gcorecloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToTaskListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
 	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
 		return TaskPage{pagination.LinkedPageBase{PageResult: r}}
 	})
+}
+
+// ListAll returns all Tasks.
+func ListAll(c *gcorecloud.ServiceClient, opts ListOptsBuilder) ([]Task, error) {
+	page, err := List(c, opts).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	return ExtractTasks(page)
 }
 
 // Get retrieves a specific cluster template based on its unique ID.

--- a/gcore/task/v1/tasks/requests.go
+++ b/gcore/task/v1/tasks/requests.go
@@ -44,7 +44,7 @@ func (opts ListOpts) isValid() error {
 	if opts.FromTimestamp != nil {
 		_, err := time.Parse(time.RFC3339, *opts.FromTimestamp)
 		if err != nil {
-			return fmt.Errorf(`timestamp "%s" should be ISO format string`, opts.FromTimestamp)
+			return fmt.Errorf(`timestamp "%s" should be RFC3339 format string`, opts.FromTimestamp)
 		}
 	}
 

--- a/gcore/task/v1/tasks/results.go
+++ b/gcore/task/v1/tasks/results.go
@@ -63,6 +63,7 @@ type TaskPage struct {
 
 type TaskID string
 type TaskState string
+type TaskOrderByChoices string
 
 const (
 	TaskStateNew      = TaskState("NEW")
@@ -70,8 +71,8 @@ const (
 	TaskStateFinished = TaskState("FINISHED")
 	TaskStateError    = TaskState("ERROR")
 
-	TaskSortingOldFirst   = "asc"
-	TaskSortingToNewFirst = "desc"
+	TaskSortingOldFirst   = TaskOrderByChoices("asc")
+	TaskSortingToNewFirst = TaskOrderByChoices("desc")
 )
 
 type TaskResults struct {

--- a/gcore/task/v1/tasks/results.go
+++ b/gcore/task/v1/tasks/results.go
@@ -69,6 +69,9 @@ const (
 	TaskStateRunning  = TaskState("RUNNING")
 	TaskStateFinished = TaskState("FINISHED")
 	TaskStateError    = TaskState("ERROR")
+
+	TaskSortingOldFirst   = "asc"
+	TaskSortingToNewFirst = "desc"
 )
 
 type TaskResults struct {

--- a/gcore/task/v1/tasks/testing/requests_test.go
+++ b/gcore/task/v1/tasks/testing/requests_test.go
@@ -51,7 +51,7 @@ func TestList(t *testing.T) {
 	client := fake.ServiceTokenClient("tasks", "v1")
 	count := 0
 
-	err := tasks.List(client).EachPage(func(page pagination.Page) (bool, error) {
+	err := tasks.ListActive(client).EachPage(func(page pagination.Page) (bool, error) {
 		count++
 		actual, err := tasks.ExtractTasks(page)
 		require.NoError(t, err)

--- a/gcore/task/v1/tasks/urls.go
+++ b/gcore/task/v1/tasks/urls.go
@@ -9,3 +9,7 @@ func resourceURL(c *gcorecloud.ServiceClient, id string) string {
 func getURL(c *gcorecloud.ServiceClient, id string) string {
 	return resourceURL(c, id)
 }
+
+func listActiveURL(c *gcorecloud.ServiceClient) string {
+	return c.ServiceURL("active")
+}

--- a/gcore/task/v1/tasks/urls.go
+++ b/gcore/task/v1/tasks/urls.go
@@ -6,14 +6,6 @@ func resourceURL(c *gcorecloud.ServiceClient, id string) string {
 	return c.BaseServiceURL("tasks", id)
 }
 
-func rootURL(c *gcorecloud.ServiceClient) string {
-	return c.ServiceURL("active")
-}
-
 func getURL(c *gcorecloud.ServiceClient, id string) string {
 	return resourceURL(c, id)
-}
-
-func listURL(c *gcorecloud.ServiceClient) string {
-	return rootURL(c)
 }


### PR DESCRIPTION
This PR builds on top of #166 and makes the necessary changes such that the SDK maintains backward compatibility, namely the following changes are made:
- `tasks.List()` maintains the same interface as before so that there are no breaking changes, and is marked as `Deprecated` guiding SDK users that they should use either `tasks.ListActive()` or `tasks.ListWithOpts()`, see more details below.
- new `tasks.ListActive()` function that returns the *active* tasks and targets the [List active tasks](https://api.gcore.com/docs/cloud#tag/Tasks/operation/TasksActiveInProjectViewSet.get) API endpoint.
- new `tasks.ListWithOpts()` function that accepts the additional parameter `opts ListOptsBuilder`, which allows tasks to be filtered by a predefined set of filters (projectID, state, taskType, ...). As proposed in #166.
- the code of the `gcoreclient task list` CLI subcommand was changed to make explicit that it returns only active tasks by changing from `tasks.List` to `tasks.ListActive` even though both return the same result.