### PR TITLE
GCLOUD2-17779 Add request_id to error message

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -102,7 +102,7 @@ func (e *ErrUnexpectedResponseCode) ReadGcoreError() {
 	gcoreErr := GcoreErrorType{}
 	err := json.Unmarshal(e.Body, &gcoreErr)
 	if err == nil {
-		e.Info = gcoreErr.Message
+		e.Info = fmt.Sprintf("%s RequestID: %s", gcoreErr.Message, gcoreErr.RequestID)
 	}
 }
 

--- a/results.go
+++ b/results.go
@@ -714,6 +714,7 @@ type GcoreErrorType struct {
 	ExceptionClass string `json:"exception_class"`
 	Message        string `json:"message"`
 	Traceback      string `json:"traceback"`
+	RequestID      string `json:"request_id"`
 }
 
 type MAC struct {


### PR DESCRIPTION
This PR adds the `request_id` to the error message of requests made to the Cloud API.

The following example shows how the error message looks like when using the SDK, for querying a Task with a non-existing id (`"f19f3966-07fb-432d-8a5d-dfd2d3f771a8"`):

```go

import (
    ....
    "github.com/G-Core/gcorelabscloud-go/gcore/task/v1/tasks"
    "log"
)
... 
r := tasks.Get(client, "f19f3966-07fb-432d-8a5d-dfd2d3f771a8")
if r.Err != nil {
    log.Fatalf("Failed to get task: %v", r.Err)
}
```
the output will be:
```
2025/02/21 15:09:12 Failed to get task: The task(f19f3966-07fb-432d-8a5d-dfd2d3f771a8) not found. RequestID: ca8ff73e0cf17866b8dfc267052710fc
```

Similarly, when using the `gcoreclient` CLI:
```bash
> gcoreclient task show f19f3966-07fb-432d-8a5d-dfd2d3f771a8
The task(f19f3966-07fb-432d-8a5d-dfd2d3f771a8) not found. RequestID: d01d1eba91e49dfe975e729a91b908ef
```