### PR TITLE
GCLOUD2-18370 Add GPU Cluster Rename

### DIFF
--- a/gcore/gpu/v3/clusters/requests.go
+++ b/gcore/gpu/v3/clusters/requests.go
@@ -2,11 +2,50 @@ package clusters
 
 import (
 	gcorecloud "github.com/G-Core/gcorelabscloud-go"
+	"net/http"
 )
+
+// RenameClusterOptsBuilder allows extensions to add parameters to rename cluster options.
+type RenameClusterOptsBuilder interface {
+	ToRenameClusterActionMap() (map[string]interface{}, error)
+}
+
+// RenameClusterOpts specifies the parameters for the Rename method.
+type RenameClusterOpts struct {
+	Name string `json:"name" required:"true" validate:"required"`
+}
+
+// Validate checks if the provided options are valid.
+func (opts RenameClusterOpts) Validate() error {
+	return gcorecloud.ValidateStruct(opts)
+}
+
+// ToRenameClusterActionMap builds a request body from RenameInstanceOpts.
+func (opts RenameClusterOpts) ToRenameClusterActionMap() (map[string]interface{}, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
+	return gcorecloud.BuildRequestBody(opts, "")
+}
 
 // Get retrieves a specific GPU cluster by its ID.
 func Get(client *gcorecloud.ServiceClient, clusterID string) (r GetResult) {
 	url := ClusterURL(client, clusterID)
 	_, r.Err = client.Get(url, &r.Body, nil)
+	return
+}
+
+// Rename changes the name of a GPU cluster.
+func Rename(client *gcorecloud.ServiceClient, clusterID string, opts RenameClusterOptsBuilder) (r GetResult) {
+	b, err := opts.ToRenameClusterActionMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	url := ClusterURL(client, clusterID)
+	_, r.Err = client.Patch(url, b, &r.Body, &gcorecloud.RequestOpts{ // nolint
+		OkCodes: []int{http.StatusOK},
+	})
 	return
 }


### PR DESCRIPTION
Add the ability to rename a GPU cluster using the SDK.

How to test:
- First, create a GPU cluster, and then use the following snippet and fill in the `cluster_id` of the created cluster.

```go
import (
    ...
	"github.com/G-Core/gcorelabscloud-go/gcore/gpu/v3/clusters"
    ...
)

func main() {
	client, err := gcore.ClientServiceFromProvider(provider, gcorecloud.EndpointOpts{
		Name:    "gpu/virtual",
		Region:  <region_id>,
		Project: <project_id>,
		Version: "v3",
	})
	if err != nil {
		log.Fatalf("Failed to create client: %v", err)
	}
	clusterID := "<cluster_id>"
	result := clusters.Get(client, clusterID)
	if result.Err != nil {...}

	cluster, err := result.Extract()
	if err != nil {...}
	fmt.Printf("Cluster name: %s\n", cluster.Name)

	opts := clusters.RenameClusterOpts{
		Name: "new-cluster-name",
	}
	result = clusters.Rename(client, clusterID, opts)
	renamedCluster, err := result.Extract()
	if err != nil {...}
	fmt.Printf("Renamed cluster name: %s\n", renamedCluster.Name)
}
```