### PR TITLE
GCLOUD2-18413 Add GPU Delete cluster

### DIFF
--- a/client/gpu/v3/clusters/clusters.go
+++ b/client/gpu/v3/clusters/clusters.go
@@ -1,10 +1,13 @@
 package clusters
 
 import (
+	"fmt"
 	gcorecloud "github.com/G-Core/gcorelabscloud-go"
 	"github.com/G-Core/gcorelabscloud-go/client/gpu/v3/client"
+	task_client "github.com/G-Core/gcorelabscloud-go/client/tasks/v1/client"
 	"github.com/G-Core/gcorelabscloud-go/client/utils"
 	"github.com/G-Core/gcorelabscloud-go/gcore/gpu/v3/clusters"
+	"github.com/G-Core/gcorelabscloud-go/gcore/task/v1/tasks"
 	"github.com/urfave/cli/v2"
 )
 
@@ -38,6 +41,52 @@ func showBaremetalClusterAction(c *cli.Context) error {
 	return showClusterAction(c, client.NewGPUBaremetalClientV3)
 }
 
+func deleteClusterAction(c *cli.Context, newClient func(*cli.Context) (*gcorecloud.ServiceClient, error)) error {
+	clusterID := c.Args().First()
+	if clusterID == "" {
+		_ = cli.ShowCommandHelp(c, "delete")
+		return cli.Exit("cluster ID is required", 1)
+	}
+
+	gpuClient, err := newClient(c)
+	if err != nil {
+		_ = cli.ShowAppHelp(c)
+		return cli.Exit(err, 1)
+	}
+
+	results, err := clusters.Delete(gpuClient, clusterID).Extract()
+	if err != nil {
+		return cli.Exit(err, 1)
+	}
+
+	taskClient, err := task_client.NewTaskClientV1(c)
+	if err != nil {
+		_ = cli.ShowAppHelp(c)
+		return cli.Exit(err, 1)
+	}
+
+	return utils.WaitTaskAndShowResult(c, taskClient, results, false, func(task tasks.TaskID) (interface{}, error) {
+		_, err := clusters.Get(gpuClient, clusterID).Extract()
+		if err == nil {
+			return nil, fmt.Errorf("cannot delete GPU cluster with ID: %s. Error: %w", clusterID, err)
+		}
+		switch err.(type) {
+		case gcorecloud.ErrDefault404:
+			return nil, nil
+		default:
+			return nil, err
+		}
+	})
+}
+
+func deleteVirtualClusterAction(c *cli.Context) error {
+	return deleteClusterAction(c, client.NewGPUVirtualClientV3)
+}
+
+func deleteBaremetalClusterAction(c *cli.Context) error {
+	return deleteClusterAction(c, client.NewGPUBaremetalClientV3)
+}
+
 // BaremetalCommands returns commands for managing baremetal GPU clusters
 func BaremetalCommands() *cli.Command {
 	return &cli.Command{
@@ -52,6 +101,14 @@ func BaremetalCommands() *cli.Command {
 				Category:    "clusters",
 				ArgsUsage:   "<cluster_id>",
 				Action:      showBaremetalClusterAction,
+			},
+			{
+				Name:        "delete",
+				Usage:       "Delete baremetal GPU cluster",
+				Description: "Delete a specific baremetal GPU cluster",
+				Category:    "clusters",
+				ArgsUsage:   "<cluster_id>",
+				Action:      deleteBaremetalClusterAction,
 			},
 		},
 	}
@@ -71,6 +128,14 @@ func VirtualCommands() *cli.Command {
 				Category:    "clusters",
 				ArgsUsage:   "<cluster_id>",
 				Action:      showVirtualClusterAction,
+			},
+			{
+				Name:        "delete",
+				Usage:       "Delete virtual GPU cluster",
+				Description: "Delete a specific virtual GPU cluster",
+				Category:    "clusters",
+				ArgsUsage:   "<cluster_id>",
+				Action:      deleteVirtualClusterAction,
 			},
 		},
 	}

--- a/gcore/gpu/v3/clusters/requests.go
+++ b/gcore/gpu/v3/clusters/requests.go
@@ -2,6 +2,7 @@ package clusters
 
 import (
 	gcorecloud "github.com/G-Core/gcorelabscloud-go"
+	"github.com/G-Core/gcorelabscloud-go/gcore/task/v1/tasks"
 	"net/http"
 )
 
@@ -32,6 +33,13 @@ func (opts RenameClusterOpts) ToRenameClusterActionMap() (map[string]interface{}
 func Get(client *gcorecloud.ServiceClient, clusterID string) (r GetResult) {
 	url := ClusterURL(client, clusterID)
 	_, r.Err = client.Get(url, &r.Body, nil)
+	return
+}
+
+// Delete removes a specific GPU cluster by its ID.
+func Delete(client *gcorecloud.ServiceClient, clusterID string) (r tasks.Result) {
+	url := ClusterURL(client, clusterID)
+	_, r.Err = client.DeleteWithResponse(url, &r.Body, nil) // nolint
 	return
 }
 


### PR DESCRIPTION
Add the ability to Delete a GPU cluster using the SDK and the CLI.

How to test using the CLI:

```bash
gcoreclient gpu virtual clusters delete <cluster_id>
```