### PR TITLE
GCLOUD2-17858 Add list GPU clusters

### DIFF
--- a/client/gpu/v3/clusters/clusters.go
+++ b/client/gpu/v3/clusters/clusters.go
@@ -148,9 +148,9 @@ func getServerSettings(c *cli.Context) (clusters.ServerSettingsOpts, error) {
 		return clusters.ServerSettingsOpts{}, err
 	}
 	credentialOpts := clusters.ServerCredentialsOpts{
-		Username:    c.String("server-username"),
-		Password:    c.String("server-password"),
-		KeypairName: c.String("keypair"),
+		Username:   c.String("server-username"),
+		Password:   c.String("server-password"),
+		SSHKeyName: c.String("ssh-key-name"),
 	}
 
 	serverSettings := clusters.ServerSettingsOpts{
@@ -292,7 +292,7 @@ func createClusterFlags() []cli.Flag {
 			Required: false,
 		},
 		&cli.StringFlag{
-			Name:     "keypair",
+			Name:     "ssh-key-name",
 			Aliases:  []string{"k"},
 			Usage:    "(ssh) keypair name for the servers in the cluster",
 			Required: false,

--- a/client/gpu/v3/clusters/clusters.go
+++ b/client/gpu/v3/clusters/clusters.go
@@ -27,12 +27,12 @@ func showClusterAction(c *cli.Context, newClient func(*cli.Context) (*gcorecloud
 		return cli.Exit(err, 1)
 	}
 
-	imageDetails := clusters.Get(gpuClient, clusterID)
-	if imageDetails.Err != nil {
-		return cli.Exit(imageDetails.Err, 1)
+	clusterDetails := clusters.Get(gpuClient, clusterID)
+	if clusterDetails.Err != nil {
+		return cli.Exit(clusterDetails.Err, 1)
 	}
 
-	utils.ShowResults(imageDetails.Body, c.String("format"))
+	utils.ShowResults(clusterDetails.Body, c.String("format"))
 	return nil
 }
 
@@ -414,7 +414,7 @@ func listBaremetalClustersAction(c *cli.Context) error {
 func BaremetalCommands() *cli.Command {
 	return &cli.Command{
 		Name:        "clusters",
-		Usage:       "Manage baremetal GPU images",
+		Usage:       "Manage baremetal GPU clusters",
 		Description: "Commands for managing baremetal GPU clusters",
 		Subcommands: []*cli.Command{
 			{
@@ -449,7 +449,7 @@ func BaremetalCommands() *cli.Command {
 func VirtualCommands() *cli.Command {
 	return &cli.Command{
 		Name:        "clusters",
-		Usage:       "Manage virtual GPU images",
+		Usage:       "Manage virtual GPU clusters",
 		Description: "Commands for managing virtual GPU clusters",
 		Subcommands: []*cli.Command{
 			{

--- a/client/gpu/v3/clusters/clusters.go
+++ b/client/gpu/v3/clusters/clusters.go
@@ -388,12 +388,7 @@ func listClustersAction(c *cli.Context, newClient func(*cli.Context) (*gcoreclou
 		return cli.Exit(err, 1)
 	}
 	opts := &clusters.ListOpts{}
-	pages, err := clusters.List(gpuClient, opts).AllPages()
-	if err != nil {
-		return cli.Exit(err, 1)
-	}
-
-	clusterList, err := clusters.ExtractClusters(pages)
+	clusterList, err := clusters.ListAll(gpuClient, opts)
 	if err != nil {
 		return cli.Exit(err, 1)
 	}

--- a/gcore/gpu/v3/clusters/requests.go
+++ b/gcore/gpu/v3/clusters/requests.go
@@ -3,6 +3,7 @@ package clusters
 import (
 	gcorecloud "github.com/G-Core/gcorelabscloud-go"
 	"github.com/G-Core/gcorelabscloud-go/gcore/task/v1/tasks"
+	"github.com/G-Core/gcorelabscloud-go/pagination"
 	"net/http"
 )
 
@@ -27,6 +28,44 @@ func (opts RenameClusterOpts) ToRenameClusterActionMap() (map[string]interface{}
 		return nil, err
 	}
 	return gcorecloud.BuildRequestBody(opts, "")
+}
+
+// ListClustersOptsBuilder allows extensions to add additional parameters to the List request.
+type ListClustersOptsBuilder interface {
+	ToListClustersQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through the API.
+type ListOpts struct {
+	Limit  int `q:"limit" validate:"omitempty,gt=0"`
+	Offset int `q:"offset" validate:"omitempty,gt=0"`
+}
+
+// ToListClustersQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToListClustersQuery() (string, error) {
+	if err := gcorecloud.ValidateStruct(opts); err != nil {
+		return "", err
+	}
+	q, err := gcorecloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List retrieves list of GPU flavors
+func List(client *gcorecloud.ServiceClient, opts ListClustersOptsBuilder) pagination.Pager {
+	url := ClustersURL(client)
+	if opts != nil {
+		query, err := opts.ToListClustersQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ClusterPage{pagination.LinkedPageBase{PageResult: r}}
+	})
 }
 
 type ServerCredentialsOpts struct {

--- a/gcore/gpu/v3/clusters/requests.go
+++ b/gcore/gpu/v3/clusters/requests.go
@@ -38,7 +38,7 @@ type ListClustersOptsBuilder interface {
 // ListOpts allows the filtering and sorting of paginated collections through the API.
 type ListOpts struct {
 	Limit  int `q:"limit" validate:"omitempty,gt=0"`
-	Offset int `q:"offset" validate:"omitempty,gt=0"`
+	Offset int `q:"offset" validate:"omitempty,gte=0"`
 }
 
 // ToListClustersQuery formats a ListOpts into a query string.

--- a/gcore/gpu/v3/clusters/requests.go
+++ b/gcore/gpu/v3/clusters/requests.go
@@ -69,9 +69,9 @@ func List(client *gcorecloud.ServiceClient, opts ListClustersOptsBuilder) pagina
 }
 
 type ServerCredentialsOpts struct {
-	Username    string `json:"username,omitempty"`
-	Password    string `json:"password,omitempty"`
-	KeypairName string `json:"keypair_name,omitempty"`
+	Username   string `json:"username,omitempty"`
+	Password   string `json:"password,omitempty"`
+	SSHKeyName string `json:"ssh_key_name,omitempty"`
 }
 
 type ServerSettingsOpts struct {

--- a/gcore/gpu/v3/clusters/requests.go
+++ b/gcore/gpu/v3/clusters/requests.go
@@ -68,6 +68,15 @@ func List(client *gcorecloud.ServiceClient, opts ListClustersOptsBuilder) pagina
 	})
 }
 
+// ListAll retrieves all GPU clusters, using the provided ListClustersOptsBuilder to filter results.
+func ListAll(client *gcorecloud.ServiceClient, opts ListClustersOptsBuilder) ([]Cluster, error) {
+	allPages, err := List(client, opts).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	return ExtractClusters(allPages)
+}
+
 type ServerCredentialsOpts struct {
 	Username   string `json:"username,omitempty"`
 	Password   string `json:"password,omitempty"`

--- a/gcore/gpu/v3/clusters/results.go
+++ b/gcore/gpu/v3/clusters/results.go
@@ -142,14 +142,14 @@ func (i *InterfaceUnion) UnmarshalJSON(data []byte) error {
 
 // Volume represents a volume structure.
 type Volume struct {
-	Size                 int                      `json:"size"`
-	Type                 VolumeType               `json:"type"`
-	DeletedOnTermination bool                     `json:"deleted_on_termination"`
-	Metadata             []map[string]interface{} `json:"metadata"`
-	Name                 *string                  `json:"name"`
-	BootIndex            *int                     `json:"boot_index"`
-	ImageID              *string                  `json:"image_id"`
-	SnapshotID           *string                  `json:"snapshot_id"`
+	Size                int                      `json:"size"`
+	Type                VolumeType               `json:"type"`
+	DeleteOnTermination bool                     `json:"delete_on_termination"`
+	Tags                []map[string]interface{} `json:"tags"`
+	Name                *string                  `json:"name"`
+	BootIndex           *int                     `json:"boot_index"`
+	ImageID             *string                  `json:"image_id"`
+	SnapshotID          *string                  `json:"snapshot_id"`
 }
 
 type ClusterServerSettings struct {
@@ -157,7 +157,7 @@ type ClusterServerSettings struct {
 	SecurityGroups []string         `json:"security_groups"`
 	Volumes        []Volume         `json:"volumes"`
 	UserData       string           `json:"user_data"`
-	KeypairName    *string          `json:"keypair_name"`
+	SSHKeyName     *string          `json:"ssh_key_name"`
 }
 
 type Cluster struct {

--- a/gcore/gpu/v3/clusters/results.go
+++ b/gcore/gpu/v3/clusters/results.go
@@ -142,14 +142,14 @@ func (i *InterfaceUnion) UnmarshalJSON(data []byte) error {
 
 // Volume represents a volume structure.
 type Volume struct {
-	Size                int                      `json:"size"`
-	Type                VolumeType               `json:"type"`
-	DeleteOnTermination bool                     `json:"delete_on_termination"`
-	Tags                []map[string]interface{} `json:"tags"`
-	Name                *string                  `json:"name"`
-	BootIndex           *int                     `json:"boot_index"`
-	ImageID             *string                  `json:"image_id"`
-	SnapshotID          *string                  `json:"snapshot_id"`
+	Size                int        `json:"size"`
+	Type                VolumeType `json:"type"`
+	DeleteOnTermination bool       `json:"delete_on_termination"`
+	Tags                []Tag      `json:"tags"`
+	Name                *string    `json:"name"`
+	BootIndex           *int       `json:"boot_index"`
+	ImageID             *string    `json:"image_id"`
+	SnapshotID          *string    `json:"snapshot_id"`
 }
 
 type ClusterServerSettings struct {
@@ -165,12 +165,20 @@ type Cluster struct {
 	Name            string                   `json:"name"`
 	Status          ClusterStatusType        `json:"status"`
 	Flavor          string                   `json:"flavor"`
-	Tags            []map[string]interface{} `json:"tags"`
+	Tags            []Tag                    `json:"tags"`
 	ServersCount    int                      `json:"servers_count"`
 	CreatedAt       gcorecloud.JSONRFC3339Z  `json:"created_at"`
 	UpdatedAt       *gcorecloud.JSONRFC3339Z `json:"updated_at"`
 	ServersIDs      *[]string                `json:"servers_ids"`
 	ServersSettings ClusterServerSettings    `json:"servers_settings"`
+}
+
+// Tag represents a key-value pair used to tag resources like clusters, servers, volumes, etc.
+// Some tags are read-only and cannot be modified by the user.
+type Tag struct {
+	Key      string `json:"key"`
+	Value    string `json:"value"`
+	ReadOnly bool   `json:"read_only"`
 }
 
 // ClusterPage is the page returned by a pager when traversing over a

--- a/gcore/gpu/v3/clusters/results.go
+++ b/gcore/gpu/v3/clusters/results.go
@@ -164,8 +164,8 @@ type Cluster struct {
 	ID              string                   `json:"id"`
 	Name            string                   `json:"name"`
 	Status          ClusterStatusType        `json:"status"`
-	FlavorID        string                   `json:"flavor_id"`
-	Metadata        []map[string]interface{} `json:"metadata"`
+	Flavor          string                   `json:"flavor"`
+	Tags            []map[string]interface{} `json:"tags"`
 	ServersCount    int                      `json:"servers_count"`
 	CreatedAt       gcorecloud.JSONRFC3339Z  `json:"created_at"`
 	UpdatedAt       *gcorecloud.JSONRFC3339Z `json:"updated_at"`

--- a/gcore/gpu/v3/clusters/results.go
+++ b/gcore/gpu/v3/clusters/results.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	gcorecloud "github.com/G-Core/gcorelabscloud-go"
+	"github.com/G-Core/gcorelabscloud-go/pagination"
 )
 
 type commonResult struct {
@@ -170,4 +171,25 @@ type Cluster struct {
 	UpdatedAt       *gcorecloud.JSONRFC3339Z `json:"updated_at"`
 	ServersIDs      *[]string                `json:"servers_ids"`
 	ServersSettings ClusterServerSettings    `json:"servers_settings"`
+}
+
+// ClusterPage is the page returned by a pager when traversing over a
+// collection of clusters.
+type ClusterPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty checks whether a ClusterPage struct is empty.
+func (r ClusterPage) IsEmpty() (bool, error) {
+	s, err := ExtractClusters(r)
+	return len(s) == 0, err
+}
+
+// ExtractClusters accepts a Page struct, specifically a ClusterPage struct,
+// and extracts the elements into a slice of cluster structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractClusters(r pagination.Page) ([]Cluster, error) {
+	var s []Cluster
+	err := r.(ClusterPage).Result.ExtractIntoSlicePtr(&s, "results")
+	return s, err
 }


### PR DESCRIPTION
Add an ability to list GPU clusters via SDK and CLI.

To test:
```go
import (
	"fmt"
	gcorecloud "github.com/G-Core/gcorelabscloud-go"
	"github.com/G-Core/gcorelabscloud-go/gcore"
	"github.com/G-Core/gcorelabscloud-go/gcore/gpu/v3/clusters"
	"log"
)

func main() {
	client, err := gcore.ClientServiceFromProvider(provider, gcorecloud.EndpointOpts{
		Name:    "gpu/virtual",
		Region:  <region_id>,
		Project: <project_id>,
		Version: "v3",
	})
	if err != nil {
		log.Fatalf("Failed to create client: %v", err)
	}
	opts := clusters.ListOpts{}
	result := clusters.List(client, opts)
	if result.Err != nil {
		fmt.Printf("Failed to list clusters: %v", result.Err)
	}
	cluster_list, err := result.AllPages()
	if err != nil {
		fmt.Printf("Failed to get all pages: %v", err)
	}
	fmt.Printf("Clusters: %+v", cluster_list)
}

```