### PR TITLE
Rename release binary to gcoreclient

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,7 +25,7 @@ builds:
         goarch: '386'
       - goos: windows
         goarch: arm64
-    binary: '{{ .ProjectName }}_v{{ .Version }}'
+    binary: gcoreclient
 archives:
   - format: zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'


### PR DESCRIPTION
Renames the binary in the release archives to `gcoreclient`as requested in https://github.com/G-Core/gcorelabscloud-go/issues/21.