### PR TITLE
Rename regionaccess command 

### DIFF
--- a/client/regionsaccess/v1/regionsaccess/regionsaccess.go
+++ b/client/regionsaccess/v1/regionsaccess/regionsaccess.go
@@ -124,7 +124,7 @@ var regionAccessCreateCommand = cli.Command{
 }
 
 var Commands = cli.Command{
-	Name:  "region",
+	Name:  "regionaccess",
 	Usage: "GCloud regions access API",
 	Subcommands: []*cli.Command{
 		&regionAccessListCommand,


### PR DESCRIPTION
Fix the duplication issue in the `gcoreclient` where there were two entries for a `region` command:

- `gcoreclient region` GCloud regions API
- `gcoreclient regionaccess` GCloud regions access API (fixed)

This issue prevented access to the regions access API using the `gcoreclient`.