### PR TITLE
GCLOUD2-18478 Add GPU Create cluster

### DIFF
--- a/client/gpu/v3/clusters/clusters.go
+++ b/client/gpu/v3/clusters/clusters.go
@@ -177,7 +177,7 @@ func getInterfaceOpts(c *cli.Context) (clusters.InterfaceOpts, error) {
 			ipFamily = clusters.IPFamilyType(ipFamilySlice[0])
 		}
 		return clusters.ExternalInterfaceOpts{
-			Name:     pointer.StringPtr(c.String("volume-name")),
+			Name:     pointer.StringPtr(c.String("interface-name")),
 			Type:     interfaceType,
 			IPFamily: ipFamily,
 		}, nil

--- a/client/gpu/v3/clusters/clusters.go
+++ b/client/gpu/v3/clusters/clusters.go
@@ -4,11 +4,14 @@ import (
 	"fmt"
 	gcorecloud "github.com/G-Core/gcorelabscloud-go"
 	"github.com/G-Core/gcorelabscloud-go/client/gpu/v3/client"
-	task_client "github.com/G-Core/gcorelabscloud-go/client/tasks/v1/client"
+	taskclient "github.com/G-Core/gcorelabscloud-go/client/tasks/v1/client"
 	"github.com/G-Core/gcorelabscloud-go/client/utils"
 	"github.com/G-Core/gcorelabscloud-go/gcore/gpu/v3/clusters"
 	"github.com/G-Core/gcorelabscloud-go/gcore/task/v1/tasks"
 	"github.com/urfave/cli/v2"
+	"k8s.io/utils/pointer"
+
+	"strings"
 )
 
 func showClusterAction(c *cli.Context, newClient func(*cli.Context) (*gcorecloud.ServiceClient, error)) error {
@@ -59,7 +62,7 @@ func deleteClusterAction(c *cli.Context, newClient func(*cli.Context) (*gcoreclo
 		return cli.Exit(err, 1)
 	}
 
-	taskClient, err := task_client.NewTaskClientV1(c)
+	taskClient, err := taskclient.NewTaskClientV1(c)
 	if err != nil {
 		_ = cli.ShowAppHelp(c)
 		return cli.Exit(err, 1)
@@ -85,6 +88,301 @@ func deleteVirtualClusterAction(c *cli.Context) error {
 
 func deleteBaremetalClusterAction(c *cli.Context) error {
 	return deleteClusterAction(c, client.NewGPUBaremetalClientV3)
+}
+
+func createVirtualClusterAction(c *cli.Context) error {
+	return createClusterAction(c, client.NewGPUVirtualClientV3)
+}
+
+func createClusterAction(c *cli.Context, newClient func(*cli.Context) (*gcorecloud.ServiceClient, error)) error {
+	gpuClient, err := newClient(c)
+	if err != nil {
+		_ = cli.ShowAppHelp(c)
+		return cli.Exit(err, 1)
+	}
+
+	// build create cluster options from CLI flags
+	serverSettings, err := getServerSettings(c)
+	if err != nil {
+		_ = cli.ShowCommandHelp(c, "create")
+		return cli.Exit(err, 1)
+	}
+	tags, err := utils.StringSliceToTags(c.StringSlice("tags"))
+	if err != nil {
+		_ = cli.ShowCommandHelp(c, "create")
+		return cli.Exit(err, 1)
+	}
+	opts := clusters.CreateClusterOpts{
+		Name:            c.String("name"),
+		Flavor:          c.String("flavor"),
+		ServersCount:    c.Int("servers-count"),
+		Tags:            tags,
+		ServersSettings: serverSettings,
+	}
+
+	// create the cluster and extract the task result
+	result := clusters.Create(gpuClient, opts)
+	if result.Err != nil {
+		return cli.Exit(result.Err, 1)
+	}
+	taskResults, err := result.Extract()
+	if err != nil {
+		return cli.Exit(err, 1)
+	}
+	utils.ShowResults(taskResults, c.String("format"))
+	return nil
+}
+
+func getServerSettings(c *cli.Context) (clusters.ServerSettingsOpts, error) {
+	interfaceOpts, err := getInterfaceOpts(c)
+	if err != nil {
+		return clusters.ServerSettingsOpts{}, err
+	}
+	volumeOpts, err := getVolumeOpts(c)
+	if err != nil {
+		return clusters.ServerSettingsOpts{}, err
+	}
+	credentialOpts := clusters.ServerCredentialsOpts{
+		Username:    c.String("username"),
+		Password:    c.String("password"),
+		KeypairName: c.String("keypair"),
+	}
+
+	serverSettings := clusters.ServerSettingsOpts{
+		Interfaces:     []clusters.InterfaceOpts{interfaceOpts},
+		Volumes:        []clusters.VolumeOpts{volumeOpts},
+		Credentials:    &credentialOpts,
+		SecurityGroups: c.StringSlice("security-groups"),
+	}
+	if c.IsSet("user-data") {
+		serverSettings.UserData = pointer.StringPtr(c.String("user-data"))
+	}
+	return serverSettings, nil
+}
+
+func getInterfaceOpts(c *cli.Context) (clusters.InterfaceOpts, error) {
+	interfaceType := utils.GetEnumStringSliceValue(c, "interface-type")[0]
+
+	source := c.String("interface-floating-source")
+	var floatingIP *clusters.FloatingIPOpts
+	if source != "" {
+		floatingIP = &clusters.FloatingIPOpts{Source: source}
+	}
+
+	switch clusters.InterfaceType(interfaceType) {
+	case clusters.External:
+		ipFamilySlice := utils.GetEnumStringSliceValue(c, "interface-ip-family")
+		var ipFamily clusters.IPFamilyType
+		if len(ipFamilySlice) > 0 {
+			ipFamily = clusters.IPFamilyType(ipFamilySlice[0])
+		}
+		return clusters.ExternalInterfaceOpts{
+			Name:     pointer.StringPtr(c.String("volume-name")),
+			Type:     interfaceType,
+			IPFamily: ipFamily,
+		}, nil
+	case clusters.Subnet:
+		return clusters.SubnetInterfaceOpts{
+			NetworkID:  c.String("interface-network-id"),
+			Name:       pointer.StringPtr(c.String("interface-name")),
+			Type:       interfaceType,
+			SubnetID:   c.String("interface-subnet-id"),
+			FloatingIP: floatingIP,
+		}, nil
+	case clusters.AnySubnet:
+		ipFamilySlice := utils.GetEnumStringSliceValue(c, "interface-ip-family")
+		var ipFamily clusters.IPFamilyType
+		if len(ipFamilySlice) > 0 {
+			ipFamily = clusters.IPFamilyType(ipFamilySlice[0])
+		}
+		return clusters.AnySubnetInterfaceOpts{
+			NetworkID:  c.String("interface-network-id"),
+			Name:       pointer.StringPtr(c.String("interface-name")),
+			Type:       interfaceType,
+			FloatingIP: floatingIP,
+			IPAddress:  pointer.StringPtr(c.String("interface-ip-address")),
+			IPFamily:   ipFamily,
+		}, nil
+	}
+	return nil, fmt.Errorf("unexpected interface-type: %v", interfaceType)
+}
+
+func getVolumeOpts(c *cli.Context) (clusters.VolumeOpts, error) {
+	volumeSource := utils.GetEnumStringSliceValue(c, "volume-source")[0]
+	volumeType := utils.GetEnumStringSliceValue(c, "volume-type")[0]
+	volume := clusters.VolumeOpts{
+		Source:              clusters.VolumeSource(volumeSource),
+		Name:                c.String("volume-name"),
+		BootIndex:           c.Int("volume-boot-index"),
+		DeleteOnTermination: c.Bool("volume-delete-on-termination"),
+		Size:                c.Int("volume-size"),
+		Type:                clusters.VolumeType(volumeType),
+		ImageID:             c.String("volume-image-id"),
+		SnapshotID:          c.String("volume-snapshot-id"),
+	}
+	if c.IsSet("volume-tags") {
+		tags, err := utils.StringSliceToTags(c.StringSlice("volume-tags"))
+		if err != nil {
+			return clusters.VolumeOpts{}, err
+		}
+		volume.Tags = tags
+	}
+	return volume, nil
+}
+
+func createClusterFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:     "name",
+			Aliases:  []string{"n"},
+			Usage:    "name of the cluster",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     "flavor",
+			Usage:    "flavor ID of the cluster",
+			Required: true,
+		},
+		&cli.StringSliceFlag{
+			Name:     "tags",
+			Aliases:  []string{"t"},
+			Usage:    "cluster key-value tags. Example: --tags key1=value1 --tags key2=value2",
+			Required: false,
+		},
+		&cli.IntFlag{
+			Name:     "servers-count",
+			Aliases:  []string{"sc"},
+			Usage:    "number of servers of the cluster",
+			Required: true,
+		},
+		&cli.StringSliceFlag{
+			Name:     "security-groups",
+			Aliases:  []string{"sg"},
+			Usage:    "security groups IDs of the cluster. Example: --security-groups b4849ffa-89f2-45a1-951f-0ae5b7809d98 --security-groups d478ae29-dedc-4869-82f0-96104425f565",
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     "user-data",
+			Aliases:  []string{"ud"},
+			Usage:    "user data for the cluster (Base64 encoded string)",
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     "username",
+			Aliases:  []string{"u"},
+			Usage:    "username for the servers in the cluster",
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     "password",
+			Aliases:  []string{"p"},
+			Usage:    "password for the servers in the cluster",
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     "keypair",
+			Aliases:  []string{"k"},
+			Usage:    "(ssh) keypair name for the servers in the cluster",
+			Required: false,
+		},
+		&cli.GenericFlag{
+			Name:    "volume-source",
+			Aliases: []string{"vs"},
+			Value: &utils.EnumStringSliceValue{
+				Enum: clusters.VolumeSourcesStringList(),
+			},
+			Usage:    fmt.Sprintf("volume source. One of %s", strings.Join(clusters.VolumeSourcesStringList(), ", ")),
+			Required: false,
+		},
+		&cli.IntFlag{
+			Name:     "volume-boot-index",
+			Usage:    "boot index of the volume",
+			Required: true,
+		},
+		&cli.BoolFlag{
+			Name:  "volume-delete-on-termination",
+			Usage: "delete volume on termination",
+		},
+		&cli.StringFlag{
+			Name:     "volume-name",
+			Aliases:  []string{"vn"},
+			Usage:    "name of the volume",
+			Required: true,
+		},
+		&cli.IntFlag{
+			Name:     "volume-size",
+			Usage:    "size of the volume",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:  "volume-image-id",
+			Usage: "image ID of the volume",
+		},
+		&cli.StringFlag{
+			Name:  "volume-snapshot-id",
+			Usage: "snapshot ID of the volume",
+		},
+		&cli.StringSliceFlag{
+			Name:  "volume-tags",
+			Usage: "tags for the volume",
+		},
+		&cli.GenericFlag{
+			Name:    "volume-type",
+			Aliases: []string{"vt"},
+			Value: &utils.EnumStringSliceValue{
+				Enum: clusters.VolumeTypesStringList(),
+			},
+			Usage: fmt.Sprintf("volume types. One of %s",
+				strings.Join(clusters.VolumeTypesStringList(), ", ")),
+			Required: false,
+		},
+		&cli.GenericFlag{
+			Name:    "interface-type",
+			Aliases: []string{"it"},
+			Value: &utils.EnumStringSliceValue{
+				Enum: clusters.InterfaceTypeStringList(),
+			},
+			Usage: fmt.Sprintf("interface type. One of %s",
+				strings.Join(clusters.InterfaceTypeStringList(), ", ")),
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     "interface-name",
+			Usage:    "name of the interface",
+			Required: false,
+		},
+		&cli.GenericFlag{
+			Name: "interface-ip-family",
+			Value: &utils.EnumStringSliceValue{
+				Enum: clusters.IPFamilyTypeListStringList(),
+			},
+			Usage: fmt.Sprintf("IP family of the interface. One of %s",
+				strings.Join(clusters.IPFamilyTypeListStringList(), ", ")),
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:  "interface-network-id",
+			Usage: "network ID of the interface",
+		},
+		&cli.StringFlag{
+			Name:  "interface-subnet-id",
+			Usage: "subnet ID of the interface",
+		},
+		&cli.StringFlag{
+			Name:  "interface-ip-address",
+			Usage: "IP address of the interface",
+		},
+		&cli.GenericFlag{
+			Name:    "interface-floating-source",
+			Aliases: []string{"ifs"},
+			Value: &utils.EnumStringSliceValue{
+				Enum: clusters.FloatingIPSourceStringList(),
+			},
+			Usage: fmt.Sprintf("floating ip source. One of %s",
+				strings.Join(clusters.FloatingIPSourceStringList(), ", ")),
+			Required: false,
+		},
+	}
 }
 
 // BaremetalCommands returns commands for managing baremetal GPU clusters
@@ -136,6 +434,14 @@ func VirtualCommands() *cli.Command {
 				Category:    "clusters",
 				ArgsUsage:   "<cluster_id>",
 				Action:      deleteVirtualClusterAction,
+			},
+			{
+				Name:        "create",
+				Usage:       "Create a new virtual GPU cluster",
+				Description: "Create a new virtual GPU cluster with the specified options",
+				Category:    "clusters",
+				Flags:       createClusterFlags(),
+				Action:      createVirtualClusterAction,
 			},
 		},
 	}

--- a/client/utils/utils.go
+++ b/client/utils/utils.go
@@ -409,3 +409,18 @@ func StructToString(item interface{}) string {
 	result := strings.Join(fields, ";")
 	return result
 }
+
+func StringSliceToTags(slice []string) (map[string]string, error) {
+	if len(slice) == 0 {
+		return nil, nil
+	}
+	m := make(map[string]string, len(slice))
+	for _, s := range slice {
+		parts := strings.SplitN(s, "=", 2)
+		if len(parts) != 2 {
+			return m, fmt.Errorf("wrong label format: %s", s)
+		}
+		m[parts[0]] = parts[1]
+	}
+	return m, nil
+}

--- a/gcore/gpu/v3/clusters/requests.go
+++ b/gcore/gpu/v3/clusters/requests.go
@@ -13,7 +13,7 @@ type RenameClusterOptsBuilder interface {
 
 // RenameClusterOpts specifies the parameters for the Rename method.
 type RenameClusterOpts struct {
-	Name string `json:"name" required:"true" validate:"required"`
+	Name string `json:"name" validate:"required"`
 }
 
 // Validate checks if the provided options are valid.
@@ -27,6 +27,98 @@ func (opts RenameClusterOpts) ToRenameClusterActionMap() (map[string]interface{}
 		return nil, err
 	}
 	return gcorecloud.BuildRequestBody(opts, "")
+}
+
+type ServerCredentialsOpts struct {
+	Username    string `json:"username"`
+	Password    string `json:"password"`
+	KeypairName string `json:"keypair_name,omitempty"`
+}
+
+type ServerSettingsOpts struct {
+	Interfaces     []InterfaceOpts        `json:"interfaces"`
+	SecurityGroups []string               `json:"security_groups,omitempty"`
+	Volumes        []VolumeOpts           `json:"volumes"`
+	UserData       *string                `json:"user_data,omitempty"`
+	Credentials    *ServerCredentialsOpts `json:"credentials,omitempty"`
+}
+
+// VolumeOpts represents options used to create a volume.
+type VolumeOpts struct {
+	Source              VolumeSource      `json:"source" validate:"required,enum"`
+	BootIndex           int               `json:"boot_index" validate:"required"`
+	DeleteOnTermination bool              `json:"delete_on_termination,omitempty"`
+	Name                string            `json:"name" validate:"required"`
+	Size                int               `json:"size,omitempty" validate:"required"`
+	ImageID             string            `json:"image_id,omitempty" validate:"rfe=Source:image,allowed_without=SnapshotID,omitempty,uuid4"`
+	SnapshotID          string            `json:"snapshot_id,omitempty" validate:"rfe=Source:snapshot,allowed_without=ImageID,omitempty,uuid4"`
+	Tags                map[string]string `json:"tags,omitempty"`
+	Type                VolumeType        `json:"type,omitempty" validate:"required,enum"`
+}
+
+type InterfaceOpts interface {
+	implInterfaceOpts()
+}
+
+func (ExternalInterfaceOpts) implInterfaceOpts()  {}
+func (SubnetInterfaceOpts) implInterfaceOpts()    {}
+func (AnySubnetInterfaceOpts) implInterfaceOpts() {}
+
+type ExternalInterfaceOpts struct {
+	Name     *string      `json:"name"`
+	Type     string       `json:"type" validate:"required"`
+	IPFamily IPFamilyType `json:"ip_family,omitempty"`
+}
+
+type FloatingIPOpts struct {
+	Source string `json:"source" validate:"required,enum"`
+}
+
+type SubnetInterfaceOpts struct {
+	NetworkID  string          `json:"network_id" validate:"required"`
+	Name       *string         `json:"name,omitempty"`
+	Type       string          `json:"type" validate:"required"`
+	SubnetID   string          `json:"subnet_id" validate:"required"`
+	FloatingIP *FloatingIPOpts `json:"floating_ip,omitempty"`
+}
+
+type AnySubnetInterfaceOpts struct {
+	NetworkID  string          `json:"network_id" validate:"required"`
+	Name       *string         `json:"name,omitempty"`
+	Type       string          `json:"type" validate:"required"`
+	IPFamily   IPFamilyType    `json:"ip_family,omitempty"`
+	IPAddress  *string         `json:"ip_address,omitempty"`
+	FloatingIP *FloatingIPOpts `json:"floating_ip,omitempty"`
+}
+
+// CreateClusterOpts allows extensions to add parameters to create cluster options.
+type CreateClusterOpts struct {
+	Name            string             `json:"name" validate:"required"`
+	Flavor          string             `json:"flavor" validate:"required"`
+	Tags            map[string]string  `json:"tags,omitempty"`
+	ServersCount    int                `json:"servers_count,omitempty"`
+	ServersSettings ServerSettingsOpts `json:"servers_settings,omitempty"`
+}
+
+// Validate checks if the provided options are valid.
+func (opts CreateClusterOpts) Validate() error {
+	return gcorecloud.ValidateStruct(opts)
+}
+
+func (opts CreateClusterOpts) ToCreateClusterMap() (map[string]interface{}, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
+	mp, err := gcorecloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return mp, nil
+}
+
+// CreateClusterOptsBuilder allows extensions to add additional parameters to the Create request.
+type CreateClusterOptsBuilder interface {
+	ToCreateClusterMap() (map[string]interface{}, error)
 }
 
 // Get retrieves a specific GPU cluster by its ID.
@@ -54,6 +146,20 @@ func Rename(client *gcorecloud.ServiceClient, clusterID string, opts RenameClust
 	url := ClusterURL(client, clusterID)
 	_, r.Err = client.Patch(url, b, &r.Body, &gcorecloud.RequestOpts{ // nolint
 		OkCodes: []int{http.StatusOK},
+	})
+	return
+}
+
+func Create(client *gcorecloud.ServiceClient, opts CreateClusterOptsBuilder) (r tasks.Result) {
+	b, err := opts.ToCreateClusterMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	url := ClustersURL(client)
+	_, r.Err = client.Post(url, b, &r.Body, &gcorecloud.RequestOpts{
+		OkCodes: []int{http.StatusOK, http.StatusCreated},
 	})
 	return
 }

--- a/gcore/gpu/v3/clusters/requests.go
+++ b/gcore/gpu/v3/clusters/requests.go
@@ -30,8 +30,8 @@ func (opts RenameClusterOpts) ToRenameClusterActionMap() (map[string]interface{}
 }
 
 type ServerCredentialsOpts struct {
-	Username    string `json:"username"`
-	Password    string `json:"password"`
+	Username    string `json:"username,omitempty"`
+	Password    string `json:"password,omitempty"`
 	KeypairName string `json:"keypair_name,omitempty"`
 }
 
@@ -65,7 +65,7 @@ func (SubnetInterfaceOpts) implInterfaceOpts()    {}
 func (AnySubnetInterfaceOpts) implInterfaceOpts() {}
 
 type ExternalInterfaceOpts struct {
-	Name     *string      `json:"name"`
+	Name     *string      `json:"name,omitempty"`
 	Type     string       `json:"type" validate:"required"`
 	IPFamily IPFamilyType `json:"ip_family,omitempty"`
 }

--- a/gcore/gpu/v3/clusters/types.go
+++ b/gcore/gpu/v3/clusters/types.go
@@ -6,8 +6,12 @@ import (
 )
 
 type IPFamilyType string
+type VolumeSource string
 type VolumeType string
 type ClusterStatusType string
+type FloatingIPSource string
+
+type InterfaceType string
 
 const (
 	IPv4IPFamilyType      IPFamilyType = "ipv4"
@@ -25,6 +29,17 @@ const (
 	Active    ClusterStatusType = "active"
 	Suspended ClusterStatusType = "suspended"
 	Error     ClusterStatusType = "error"
+
+	NewVolume VolumeSource = "new"
+	Image     VolumeSource = "image"
+	Snapshot  VolumeSource = "snapshot"
+
+	External  InterfaceType = "external"
+	Subnet    InterfaceType = "subnet"
+	AnySubnet InterfaceType = "any_subnet"
+
+	NewFloatingIP      FloatingIPSource = "new"
+	ExistingFloatingIP FloatingIPSource = "existing"
 )
 
 func (it *IPFamilyType) IsValid() error {
@@ -46,11 +61,70 @@ func (it *IPFamilyType) ValidOrNil() (*IPFamilyType, error) {
 	return it, nil
 }
 
+func InterfaceTypeList() []InterfaceType {
+	return []InterfaceType{
+		External,
+		Subnet,
+		AnySubnet,
+	}
+}
+
+func InterfaceTypeStringList() []string {
+	var s []string
+	for _, v := range InterfaceTypeList() {
+		s = append(s, v.String())
+	}
+	return s
+}
+
+func (it *InterfaceType) String() string {
+	return string(*it)
+}
+
+func (fis *FloatingIPSource) String() string {
+	return string(*fis)
+}
+
+func FloatingIPSourceList() []FloatingIPSource {
+	return []FloatingIPSource{
+		NewFloatingIP,
+		ExistingFloatingIP,
+	}
+}
+
+func FloatingIPSourceStringList() []string {
+	var s []string
+	for _, v := range FloatingIPSourceList() {
+		s = append(s, v.String())
+	}
+	return s
+}
+
+func (vs *VolumeSource) String() string {
+	return string(*vs)
+}
+
+func VolumeSourcesList() []VolumeSource {
+	return []VolumeSource{
+		NewVolume,
+		Image,
+		Snapshot,
+	}
+}
+
+func VolumeSourcesStringList() []string {
+	var s []string
+	for _, v := range VolumeSourcesList() {
+		s = append(s, v.String())
+	}
+	return s
+}
+
 func (it *IPFamilyType) String() string {
 	return string(*it)
 }
 
-func (it *IPFamilyType) List() []IPFamilyType {
+func IPFamilyTypeList() []IPFamilyType {
 	return []IPFamilyType{
 		IPv6IPFamilyType,
 		IPv4IPFamilyType,
@@ -58,9 +132,9 @@ func (it *IPFamilyType) List() []IPFamilyType {
 	}
 }
 
-func (it *IPFamilyType) StringList() []string {
+func IPFamilyTypeListStringList() []string {
 	var s []string
-	for _, v := range it.List() {
+	for _, v := range IPFamilyTypeList() {
 		s = append(s, v.String())
 	}
 	return s
@@ -109,7 +183,7 @@ func (vt *VolumeType) String() string {
 	return string(*vt)
 }
 
-func (vt *VolumeType) List() []VolumeType {
+func VolumeTypesList() []VolumeType {
 	return []VolumeType{
 		Standard,
 		SsdHiIops,
@@ -120,9 +194,9 @@ func (vt *VolumeType) List() []VolumeType {
 	}
 }
 
-func (vt *VolumeType) StringList() []string {
+func VolumeTypesStringList() []string {
 	var s []string
-	for _, v := range vt.List() {
+	for _, v := range VolumeTypesList() {
 		s = append(s, v.String())
 	}
 	return s

--- a/gcore/gpu/v3/clusters/urls.go
+++ b/gcore/gpu/v3/clusters/urls.go
@@ -6,6 +6,11 @@ const (
 	clustersPath = "clusters"
 )
 
+// ClustersURL returns URL for GPU clusters operations
+func ClustersURL(c *gcorecloud.ServiceClient) string {
+	return c.ServiceURL(clustersPath)
+}
+
 // ClusterURL returns URL for specific GPU cluster operations
 func ClusterURL(c *gcorecloud.ServiceClient, clusterID string) string {
 	return c.ServiceURL(clustersPath, clusterID)


### PR DESCRIPTION
Add the ability to Create a GPU cluster using the SDK and the CLI.

Using the CLI only it's possible to attach one volume and interface. Furthermore, the volume needs to be of source `image`.

How to test using the CLI:
```bash
./gcoreclient gpu virtual clusters create \
--name "MyTestCluster" \
--flavor "<flavor_id>" \
--tags "source=cli" \
--servers-count 1 \
--interface-type "external" \
--interface-name "MyTestCluster" \
--volume-name "MyImageTestVolume" \
--volume-size 50 \
--volume-type "standard" \
--volume-tags "creator=po" \
--volume-image-id "<image_id>" \
--server-username "admin" \
--server-password "pwd"
```