### PR TITLE
GCLOUD2-18655 Add support for listing GPU instances

### DIFF
--- a/gcore/instance/v1/instances/requests.go
+++ b/gcore/instance/v1/instances/requests.go
@@ -22,6 +22,7 @@ type ListOptsBuilder interface {
 type ListOpts struct {
 	ExcludeSecGroup   string            `q:"exclude_secgroup"`
 	AvailableFloating bool              `q:"available_floating"`
+	IncludeAI         bool              `q:"include_ai"`
 	IncludeBaremetal  bool              `q:"include_baremetal"`
 	Name              string            `q:"name"`
 	FlavorID          string            `q:"flavor_id"`


### PR DESCRIPTION
## Description

Adding missing `include_ai` query param to listing instances API ([docs](https://api.preprod.world/docs/cloud#tag/Instances/operation/InstanceViewSetV1.get)). While marked as deprecated, we need it to allow GCCM to see GPU nodes in MKaaS and there's currently no good alternative.

Required to fix GCLOUD2-18543.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] I have followed the style guidelines of this project
- [X] I have tested my changes with the latest version of Go