### PR TITLE
MKAAS-1518 Fix AI metadata and delete node opts

### DIFF
--- a/gcore/ai/v1/ais/requests.go
+++ b/gcore/ai/v1/ais/requests.go
@@ -57,7 +57,7 @@ type CreateOpts struct {
 	Password       string                                  `json:"password" validate:"omitempty,required_with=Username"`
 	Username       string                                  `json:"username" validate:"omitempty,required_with=Password"`
 	UserData       string                                  `json:"user_data,omitempty" validate:"omitempty,base64"`
-	Metadata       map[string]string                       `json:"metadata,omitempty" validate:"omitempty,dive"`
+	Metadata       map[string]string                       `json:"metadata,omitempty" validate:"omitempty"`
 	InstancesCount int                                     `json:"instances_count,omitempty" validate:"omitempty,min=1"`
 }
 
@@ -458,7 +458,7 @@ type DeleteNodeOpts struct {
 }
 
 // ToDeleteNodeFromGPUClusterQuery formats a DeleteNodeOpts into a query string.
-func (opts *DeleteNodeOpts) ToDeleteNodeFromGPUClusterQuery() (string, error) {
+func (opts DeleteNodeOpts) ToDeleteNodeFromGPUClusterQuery() (string, error) {
 	if err := opts.Validate(); err != nil {
 		return "", err
 	}
@@ -475,7 +475,7 @@ func (opts *DeleteNodeOpts) Validate() error {
 
 // DeleteNodeFromGPUCluster deletes a single node from a GPU cluster.
 func DeleteNodeFromGPUCluster(
-	client *gcorecloud.ServiceClient, clusterID, instanceID string, opts DeleteNodeOpts) (r tasks.Result) {
+	client *gcorecloud.ServiceClient, clusterID, instanceID string, opts DeleteNodeOptsBuilder) (r tasks.Result) {
 
 	url := nodeFromGPUClusterURL(client, clusterID, instanceID)
 	query, err := opts.ToDeleteNodeFromGPUClusterQuery()

--- a/gcore/ai/v1/ais/testing/fixtures.go
+++ b/gcore/ai/v1/ais/testing/fixtures.go
@@ -532,6 +532,9 @@ const CreateRequest = `
   ],
   "username": "useruser",
   "password": "secret",
+  "metadata": {
+      "foo": "bar"
+  },
   "name": "ivandts",
   "volumes": [
       {

--- a/gcore/ai/v1/ais/testing/requests_test.go
+++ b/gcore/ai/v1/ais/testing/requests_test.go
@@ -363,6 +363,9 @@ func TestCreate(t *testing.T) {
 				},
 			},
 		},
+		Metadata: map[string]string{
+			"foo": "bar",
+		},
 		Password: "secret",
 		Username: "useruser",
 	}


### PR DESCRIPTION
## Description

1. Fixed an issue with passing metadata to v1 create ai cluster request. The `dive` validator without anything following it caused `panic: runtime error: invalid memory address or nil pointer dereference`.
2. `DeleteNodeFromGPUCluster` now accepts `DeleteNodeOptsBuilder` instead of `DeleteNodeOpts` as it should from the beginning.

Both changes are entirely backwards compatible, requiring no changes in existing code.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have followed the style guidelines of this project
- [x] I have tested my changes with the latest version of Go

## Further comments

None