### PR TITLE
GCLOUD2-18391 Add extract from task

### DIFF
--- a/gcore/gpu/v3/clusters/results.go
+++ b/gcore/gpu/v3/clusters/results.go
@@ -204,17 +204,14 @@ func ExtractClusters(r pagination.Page) ([]Cluster, error) {
 }
 
 type ClusterTaskResult struct {
-	Clusters []string `mapstructure:"instances"`
+	ClusterID string `mapstructure:"cluster_id"`
 }
 
 func ExtractGPUClusterIDFromTask(task *tasks.Task) (string, error) {
 	var result ClusterTaskResult
-	err := gcorecloud.NativeMapToStruct(task.CreatedResources, &result)
+	err := gcorecloud.NativeMapToStruct(task.Data, &result)
 	if err != nil {
 		return "", fmt.Errorf("cannot decode AI cluster information in task structure: %w", err)
 	}
-	if len(result.Clusters) == 0 {
-		return "", fmt.Errorf("cannot decode ai cluster information in task structure: %w", err)
-	}
-	return result.Clusters[0], nil
+	return result.ClusterID, nil
 }

--- a/gcore/gpu/v3/clusters/results.go
+++ b/gcore/gpu/v3/clusters/results.go
@@ -204,7 +204,7 @@ func ExtractClusters(r pagination.Page) ([]Cluster, error) {
 }
 
 type ClusterTaskResult struct {
-	Clusters []string `mapstructure:"ai_clusters"`
+	Clusters []string `mapstructure:"instances"`
 }
 
 func ExtractGPUClusterIDFromTask(task *tasks.Task) (string, error) {

--- a/gcore/gpu/v3/clusters/results.go
+++ b/gcore/gpu/v3/clusters/results.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	gcorecloud "github.com/G-Core/gcorelabscloud-go"
+	"github.com/G-Core/gcorelabscloud-go/gcore/task/v1/tasks"
 	"github.com/G-Core/gcorelabscloud-go/pagination"
 )
 
@@ -200,4 +201,20 @@ func ExtractClusters(r pagination.Page) ([]Cluster, error) {
 	var s []Cluster
 	err := r.(ClusterPage).Result.ExtractIntoSlicePtr(&s, "results")
 	return s, err
+}
+
+type ClusterTaskResult struct {
+	Clusters []string `mapstructure:"ai_clusters"`
+}
+
+func ExtractGPUClusterIDFromTask(task *tasks.Task) (string, error) {
+	var result ClusterTaskResult
+	err := gcorecloud.NativeMapToStruct(task.CreatedResources, &result)
+	if err != nil {
+		return "", fmt.Errorf("cannot decode AI cluster information in task structure: %w", err)
+	}
+	if len(result.Clusters) == 0 {
+		return "", fmt.Errorf("cannot decode ai cluster information in task structure: %w", err)
+	}
+	return result.Clusters[0], nil
 }

--- a/gcore/gpu/v3/clusters/results.go
+++ b/gcore/gpu/v3/clusters/results.go
@@ -157,7 +157,7 @@ type ClusterServerSettings struct {
 	Interfaces     []InterfaceUnion `json:"interfaces"`
 	SecurityGroups []string         `json:"security_groups"`
 	Volumes        []Volume         `json:"volumes"`
-	UserData       string           `json:"user_data"`
+	UserData       *string          `json:"user_data"`
 	SSHKeyName     *string          `json:"ssh_key_name"`
 }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

This PR performs the following changes:
- Add `ExtractGPUClusterIDFromTask` utility function that allows the extraction of the `cluster_id` from a Task.
- Make `UserData` a pointer (so it can be nil) in the Virtual GPU get/list cluster responses.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!-- Put an "x" in the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I have followed the style guidelines of this project
- [x] I have tested my changes with the latest version of Go

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... --> 