### PR TITLE
GCLOUD2-19095 Make image size int64

### DIFF
--- a/gcore/image/v1/images/results.go
+++ b/gcore/image/v1/images/results.go
@@ -51,7 +51,7 @@ type Image struct {
 	DisplayOrder  int                      `json:"display_order"`
 	CreatedAt     gcorecloud.JSONRFC3339Z  `json:"created_at"`
 	UpdatedAt     *gcorecloud.JSONRFC3339Z `json:"updated_at"`
-	Size          int                      `json:"size"`
+	Size          int64                    `json:"size"`
 	CreatorTaskID *string                  `json:"creator_task_id"`
 	TaskID        *string                  `json:"task_id"`
 	Region        string                   `json:"region"`


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

The `Image.size` field is defined as `int` but this causes error on 32bit architectures when the size is too big to fit an `int32` which is the `int` size on 32bit arch. This causes errors such as this:

```
Error: json: cannot unmarshal number 17179869184 into Go struct field Image.size of type int
```

This PR addresses this problem by making `Image.size` an `int64`, which will ensure a big size number can fit inside this variable.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!-- Put an "x" in the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I have followed the style guidelines of this project
- [x] I have tested my changes with the latest version of Go

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... --> 