### PR TITLE
MKAAS-1568 Fix listing gpu clusters in resizing state

### DIFF
--- a/gcore/gpu/v3/clusters/types.go
+++ b/gcore/gpu/v3/clusters/types.go
@@ -29,7 +29,9 @@ const (
 
 	New       ClusterStatusType = "new"
 	Active    ClusterStatusType = "active"
+	Resizing  ClusterStatusType = "resizing"
 	Suspended ClusterStatusType = "suspended"
+	Deleting  ClusterStatusType = "deleting"
 	Error     ClusterStatusType = "error"
 
 	NewVolume VolumeSource = "new"
@@ -156,10 +158,6 @@ func (it *IPFamilyType) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	v := IPFamilyType(s)
-	err := v.IsValid()
-	if err != nil {
-		return err
-	}
 	*it = v
 	return nil
 }
@@ -218,10 +216,6 @@ func (vt *VolumeType) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	v := VolumeType(s)
-	err := v.IsValid()
-	if err != nil {
-		return err
-	}
 	*vt = v
 	return nil
 }
@@ -278,10 +272,6 @@ func (ct *ClusterStatusType) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	v := ClusterStatusType(s)
-	err := v.IsValid()
-	if err != nil {
-		return err
-	}
 	*ct = v
 	return nil
 }
@@ -345,10 +335,6 @@ func (ca *ClusterAction) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	v := ClusterAction(s)
-	err := v.IsValid()
-	if err != nil {
-		return err
-	}
 	*ca = v
 	return nil
 }


### PR DESCRIPTION
## Description

This PR fixes the following error:

```
$ gcoreclient api-token gpu baremetal clusters list

invalid ClusterStatusType type: resizing
exit status 1
```

I added missing bare metal GPU cluster statuses (`resizing` and `deleting`).

I also removed validation from unmarshaling all GPU cluster related enums, because the root cause is having response validation.

IMHO we should validate requests, but never responses. That's because response validation on the SDK side turns any additive change on the backend (e.g. adding a new enum field) into a breaking change for existing code running older versions of the SDK.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have followed the style guidelines of this project
- [x] I have tested my changes with the latest version of Go

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... --> 