### PR TITLE
GCLOUD2-19947 Improve management of virtual gpu cluster tags

### DIFF
--- a/client/utils/utils.go
+++ b/client/utils/utils.go
@@ -412,7 +412,7 @@ func StructToString(item interface{}) string {
 
 func StringSliceToTags(slice []string) (map[string]string, error) {
 	if len(slice) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("no tags provided")
 	}
 	m := make(map[string]string, len(slice))
 	for _, s := range slice {


### PR DESCRIPTION
## Description

This PR improves how users can manage tags for virtual GPU clusters. Now, users are able to delete specific tags or even to remove all tags at once. The following methods have been added to the `clusters` package:
- `RemoveTags` remove a list of tags
- `RemoveAllTags` remove all tags 
- `UpdateAndRemoveTags` add, replace and delete a set of tags (provide `nil` values for tag keys to delete). 

The `gcoreclient` CLI has also been update with a new `--remove-tags` command that allows users to remove multiple tags from a gpu cluster:

```bash
gcoreclient gpu virtual clusters updatetags --tags env=dev --remove-tags owner --remove-tags region <cluster_id>
```

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!-- Put an "x" in the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I have followed the style guidelines of this project
- [x] I have tested my changes with the latest version of Go

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... --> 