### PR TITLE
GCLOUD2-20003 Add check limits method for file shares

### DIFF
--- a/gcore/file_share/v1/file_shares/requests.go
+++ b/gcore/file_share/v1/file_shares/requests.go
@@ -273,3 +273,37 @@ func MetadataGet(client *gcorecloud.ServiceClient, id string, key string) (r Met
 	_, r.Err = client.Get(url, &r.Body, nil) // nolint
 	return
 }
+
+// CheckLimitOpts represents options used to check file share limits.
+type CheckLimitOpts struct {
+	Size int `json:"size" required:"true" validate:"required,gt=1"`
+}
+
+// ToCheckLimitsMap builds a request body from ResizeOpts.
+func (opts CheckLimitOpts) ToCheckLimitsMap() (map[string]interface{}, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
+	return gcorecloud.BuildRequestBody(opts, "")
+}
+
+// Validate validates the CheckLimitOpts structure.
+func (opts CheckLimitOpts) Validate() error {
+	return gcorecloud.TranslateValidationError(gcorecloud.Validate.Struct(opts))
+}
+
+// CheckLimitsOptsBuilder allows extensions to add additional parameters to the CheckLimits request.
+type CheckLimitsOptsBuilder interface {
+	ToCheckLimitsMap() (map[string]interface{}, error)
+}
+
+// CheckLimits checks the limits for creating a file share with the specified size.
+func CheckLimits(c *gcorecloud.ServiceClient, opts CheckLimitsOptsBuilder) (r CheckLimitsResult) {
+	b, err := opts.ToCheckLimitsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(checkLimitsURL(c), b, &r.Body, nil)
+	return
+}

--- a/gcore/file_share/v1/file_shares/results.go
+++ b/gcore/file_share/v1/file_shares/results.go
@@ -292,3 +292,23 @@ func ExtractMetadata(r pagination.Page) ([]Metadata, error) {
 type MetadataActionResult struct {
 	gcorecloud.ErrResult
 }
+
+type CheckLimitsResult struct {
+	gcorecloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a file share quota.
+func (r CheckLimitsResult) Extract() (*FileShareQuota, error) {
+	var s FileShareQuota
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+type FileShareQuota struct {
+	CountLimit     int `json:"sfs_count_limit"`
+	CountRequested int `json:"sfs_count_requested"`
+	CountUsage     int `json:"sfs_count_usage"`
+	SizeLimit      int `json:"sfs_size_limit"`
+	SizeRequested  int `json:"sfs_size_requested"`
+	SizeUsage      int `json:"sfs_size_usage"`
+}

--- a/gcore/file_share/v1/file_shares/testing/fixtures.go
+++ b/gcore/file_share/v1/file_shares/testing/fixtures.go
@@ -425,3 +425,29 @@ var (
 		},
 	}
 )
+
+const CheckLimitsRequest = `
+{
+    "size": 1001
+}
+`
+
+const CheckLimitsResponse = `
+{
+    "sfs_count_limit": 10,
+    "sfs_count_requested": 1,
+    "sfs_count_usage": 2,
+    "sfs_size_limit": 1000,
+    "sfs_size_requested": 1001,
+    "sfs_size_usage": 900
+}
+`
+
+var ExpectedCheckLimitsQuota = file_shares.FileShareQuota{
+	CountLimit:     10,
+	CountRequested: 1,
+	CountUsage:     2,
+	SizeLimit:      1000,
+	SizeRequested:  1001,
+	SizeUsage:      900,
+}

--- a/gcore/file_share/v1/file_shares/urls.go
+++ b/gcore/file_share/v1/file_shares/urls.go
@@ -55,3 +55,7 @@ func metadataURL(c *gcorecloud.ServiceClient, id string) string {
 func metadataItemURL(c *gcorecloud.ServiceClient, id string, key string) string {
 	return resourceActionURL(c, id, fmt.Sprintf("metadata_item?key=%s", key))
 }
+
+func checkLimitsURL(c *gcorecloud.ServiceClient) string {
+	return c.ServiceURL("check_limits")
+}


### PR DESCRIPTION
## Description

This PR adds support for checking quota limits of file shares using this SDK. 

API method link: https://api.gcore.com/docs/cloud#tag/File-Shares/operation/SfsCheckLimitsHandler.post

The API returns the following:
- an empty `{}` response body if the requested size (+usage) is below the limit
- a body with the requested usage and limit size values if the requested value (+usage) is above the limit.

The SDK returns the following:
- an empty struct `file_shares.FileShareQuota` if the request size is below the limit
- the struct `file_shares.FileShareQuota` is filled with respective values for requested, usage, and size limits.


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!-- Put an "x" in the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have followed the style guidelines of this project
- [x] I have tested my changes with the latest version of Go

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... --> 