### PR TITLE
GCLOUD2-19495 Add support for tags in file shares

### DIFF
--- a/client/file_shares/v1/file_shares/file_shares.go
+++ b/client/file_shares/v1/file_shares/file_shares.go
@@ -97,11 +97,6 @@ var fileShareCreateCommand = cli.Command{
 				return cli.Exit(err, 1)
 			}
 		}
-		convertedTags := make(map[string]*string, len(tags))
-		for k, v := range tags {
-			val := v
-			convertedTags[k] = &val
-		}
 
 		// Validate volume-type
 		volumeType := c.String("volume-type")
@@ -121,7 +116,7 @@ var fileShareCreateCommand = cli.Command{
 			Protocol:   c.String("protocol"),
 			Size:       c.Int("size"),
 			Access:     getAccessRules(c),
-			Tags:       convertedTags,
+			Tags:       tags,
 		}
 
 		// Validate if user provided network and subnet for default_share_type, which are required.

--- a/client/file_shares/v1/file_shares/file_shares.go
+++ b/client/file_shares/v1/file_shares/file_shares.go
@@ -244,7 +244,7 @@ var fileShareUpdateCommand = cli.Command{
 			return cli.Exit("At least one of the flags --name, --tags or --remove-tags must be provided", 1)
 		}
 
-		opts := file_shares.UpdateOpts{}
+		opts := file_shares.UpdateWithTagsOpts{}
 		if c.String("name") != "" {
 			opts.Name = c.String("name")
 		}
@@ -256,7 +256,7 @@ var fileShareUpdateCommand = cli.Command{
 			tags[tagKey] = nil // nil value indicates removal of the tag
 		}
 		opts.Tags = tags
-		fileShare, err := file_shares.Update(client, fileShareID, opts).Extract()
+		fileShare, err := file_shares.UpdateWithTags(client, fileShareID, opts).Extract()
 		if err != nil {
 			return cli.Exit(err, 1)
 		}

--- a/gcore/file_share/v1/file_shares/requests.go
+++ b/gcore/file_share/v1/file_shares/requests.go
@@ -50,7 +50,7 @@ type CreateOpts struct {
 	Size       int                    `json:"size" required:"true" validate:"required,gt=0"`
 	Network    *FileShareNetworkOpts  `json:"network,omitempty" validate:"omitempty,dive"`
 	Access     []CreateAccessRuleOpts `json:"access,omitempty" validate:"dive"`
-	Tags       map[string]*string     `json:"tags"`
+	Tags       map[string]string      `json:"tags"`
 }
 
 // ToFileShareCreateMap builds a request body from CreateOpts.

--- a/gcore/file_share/v1/file_shares/testing/requests_test.go
+++ b/gcore/file_share/v1/file_shares/testing/requests_test.go
@@ -2,21 +2,23 @@ package testing
 
 import (
 	"fmt"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 	"net/http"
 	"testing"
 
 	"github.com/G-Core/gcorelabscloud-go/gcore/file_share/v1/file_shares"
 	"github.com/G-Core/gcorelabscloud-go/gcore/task/v1/tasks"
+	"github.com/G-Core/gcorelabscloud-go/gcore/utils/metadata"
 	th "github.com/G-Core/gcorelabscloud-go/testhelper"
-	fakeclient "github.com/G-Core/gcorelabscloud-go/testhelper/client"
-	"github.comcom/G-Core/gcorelabscloud-go/gcore/utils/metadata"
+	fake "github.com/G-Core/gcorelabscloud-go/testhelper/client"
 )
 
 const fileSharePath = "/fileshares/v1/shares"
 const fileShareListPath = "/fileshares/v1/shares"
 
 var (
-	client = client.NewClient()
+	client = fake.ServiceClient()
 )
 
 func prepareListTestURLParams(projectID int, regionID int) string {
@@ -74,11 +76,11 @@ func prepareCheckLimitsTestURL() string {
 func TestList(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	client := fakeclient.ServiceTokenClient(fileSharePath, "v1")
+	client := fake.ServiceTokenClient(fileSharePath, "v1")
 
 	th.Mux.HandleFunc(fileShareListPath, func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
-		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fakeclient.AccessToken))
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -100,11 +102,11 @@ func TestList(t *testing.T) {
 func TestListAll(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	client := fakeclient.ServiceTokenClient(fileSharePath, "v1")
+	client := fake.ServiceTokenClient(fileSharePath, "v1")
 
 	th.Mux.HandleFunc(fileShareListPath, func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
-		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fakeclient.AccessToken))
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -122,11 +124,11 @@ func TestListAll(t *testing.T) {
 func TestGet(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	client := fakeclient.ServiceTokenClient(fileSharePath, "v1")
+	client := fake.ServiceTokenClient(fileSharePath, "v1")
 
 	th.Mux.HandleFunc(fmt.Sprintf("%s/%s", fileSharePath, FirstFileShare.ID), func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
-		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fakeclient.AccessToken))
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -143,11 +145,11 @@ func TestGet(t *testing.T) {
 func TestCreate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	client := fakeclient.ServiceTokenClient(fileSharePath, "v1")
+	client := fake.ServiceTokenClient(fileSharePath, "v1")
 
 	th.Mux.HandleFunc(fileSharePath, func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
-		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fakeclient.AccessToken))
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 		th.TestJSONRequest(t, r, CreateRequest)
 
 		w.Header().Add("Content-Type", "application/json")
@@ -185,11 +187,11 @@ func TestCreate(t *testing.T) {
 func TestDelete(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	client := fakeclient.ServiceTokenClient(fileSharePath, "v1")
+	client := fake.ServiceTokenClient(fileSharePath, "v1")
 
 	th.Mux.HandleFunc(fmt.Sprintf("%s/%s", fileSharePath, FirstFileShare.ID), func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "DELETE")
-		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fakeclient.AccessToken))
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, DeleteResponse)
 	})
@@ -211,11 +213,11 @@ func TestDelete(t *testing.T) {
 func TestUpdate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	client := fakeclient.ServiceTokenClient(fileSharePath, "v1")
+	client := fake.ServiceTokenClient(fileSharePath, "v1")
 
 	th.Mux.HandleFunc(fmt.Sprintf("%s/%s", fileSharePath, FirstFileShare.ID), func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "PATCH")
-		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fakeclient.AccessToken))
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 		th.TestJSONRequest(t, r, UpdateRequest)
 
 		w.Header().Add("Content-Type", "application/json")
@@ -237,11 +239,11 @@ func TestUpdate(t *testing.T) {
 func TestExtend(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	client := fakeclient.ServiceTokenClient(fileSharePath, "v1")
+	client := fake.ServiceTokenClient(fileSharePath, "v1")
 
 	th.Mux.HandleFunc(fmt.Sprintf("%s/%s/action", fileSharePath, FirstFileShare.ID), func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
-		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fakeclient.AccessToken))
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 		th.TestJSONRequest(t, r, ExtendRequest)
 
 		w.Header().Add("Content-Type", "application/json")
@@ -273,11 +275,11 @@ func TestExtend(t *testing.T) {
 func TestListAccessRules(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	client := fakeclient.ServiceTokenClient(fileSharePath, "v1")
+	client := fake.ServiceTokenClient(fileSharePath, "v1")
 
 	th.Mux.HandleFunc(fmt.Sprintf("%s/%s/access-rules", fileSharePath, FirstFileShare.ID), func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
-		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fakeclient.AccessToken))
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -297,11 +299,11 @@ func TestListAccessRules(t *testing.T) {
 func TestCreateAccessRule(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	client := fakeclient.ServiceTokenClient(fileSharePath, "v1")
+	client := fake.ServiceTokenClient(fileSharePath, "v1")
 
 	th.Mux.HandleFunc(fmt.Sprintf("%s/%s/access-rules", fileSharePath, FirstFileShare.ID), func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
-		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fakeclient.AccessToken))
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -323,11 +325,11 @@ func TestCreateAccessRule(t *testing.T) {
 func TestDeleteAccessRule(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	client := fakeclient.ServiceTokenClient(fileSharePath, "v1")
+	client := fake.ServiceTokenClient(fileSharePath, "v1")
 
 	th.Mux.HandleFunc(fmt.Sprintf("%s/%s/access-rules/%s", fileSharePath, FirstFileShare.ID, FirstAccessRule.ID), func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "DELETE")
-		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fakeclient.AccessToken))
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -341,11 +343,11 @@ func TestDeleteAccessRule(t *testing.T) {
 func TestMetadataList(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	client := fakeclient.ServiceTokenClient(fileSharePath, "v1")
+	client := fake.ServiceTokenClient(fileSharePath, "v1")
 
 	th.Mux.HandleFunc(fmt.Sprintf("%s/%s/metadata", fileSharePath, FirstFileShare.ID), func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
-		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fakeclient.AccessToken))
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -365,11 +367,11 @@ func TestMetadataList(t *testing.T) {
 func TestMetadataGet(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	client := fakeclient.ServiceTokenClient(fileSharePath, "v1")
+	client := fake.ServiceTokenClient(fileSharePath, "v1")
 
 	th.Mux.HandleFunc(fmt.Sprintf("%s/%s/metadata/%s", fileSharePath, FirstFileShare.ID, SecondMetadata.Key), func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
-		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fakeclient.AccessToken))
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -386,11 +388,11 @@ func TestMetadataGet(t *testing.T) {
 func TestMetadataCreate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	client := fakeclient.ServiceTokenClient(fileSharePath, "v1")
+	client := fake.ServiceTokenClient(fileSharePath, "v1")
 
 	th.Mux.HandleFunc(fmt.Sprintf("%s/%s/metadata", fileSharePath, FirstFileShare.ID), func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
-		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fakeclient.AccessToken))
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -408,11 +410,11 @@ func TestMetadataCreate(t *testing.T) {
 func TestMetadataUpdate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	client := fakeclient.ServiceTokenClient(fileSharePath, "v1")
+	client := fake.ServiceTokenClient(fileSharePath, "v1")
 
 	th.Mux.HandleFunc(fmt.Sprintf("%s/%s/metadata", fileSharePath, FirstFileShare.ID), func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
-		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fakeclient.AccessToken))
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -430,11 +432,11 @@ func TestMetadataUpdate(t *testing.T) {
 func TestMetadataDelete(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	client := fakeclient.ServiceTokenClient(fileSharePath, "v1")
+	client := fake.ServiceTokenClient(fileSharePath, "v1")
 
 	th.Mux.HandleFunc(fmt.Sprintf("%s/%s/metadata/%s", fileSharePath, FirstFileShare.ID, "test"), func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "DELETE")
-		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fakeclient.AccessToken))
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 
 		w.WriteHeader(http.StatusNoContent)
 	})


### PR DESCRIPTION
## Description

This PR enables users to manage tags in file shares; before, users could only create a file share with tags, but these couldn't be changed. The changes introduced allow adding, replacing, or removing tags using the SDK methods or the CLI.

The previous struct `UpdateOpts` and `Update` method have been deprecated, and users should use the following new methods:
- `UpdateWithTags` allows updating all fields (which are available for updating) in a single request, including `tags`
- `Rename` for only updating the name of a file share
- `UpdateTags` for adding or replacing tags
- `RemoveTags` for removing a list of tags
- `RemoveAllTags` for removing all tags
- `UpdateAndRemoveTags` for adding, replacing, and removing tags in a single request.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x]  New feature (non-breaking change which adds functionality)

## Checklist

<!-- Put an "x" in the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have followed the style guidelines of this project
- [x] I have tested my changes with the latest version of Go

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... --> 