### PR TITLE
GCLOUD2-20199 Support sec groups for bare metal gpu clusters

### DIFF
--- a/client/gpu/v3/clusters/clusters.go
+++ b/client/gpu/v3/clusters/clusters.go
@@ -2,6 +2,7 @@ package clusters
 
 import (
 	"fmt"
+
 	gcorecloud "github.com/G-Core/gcorelabscloud-go"
 	"github.com/G-Core/gcorelabscloud-go/client/flags"
 	"github.com/G-Core/gcorelabscloud-go/client/gpu/v3/client"
@@ -388,10 +389,19 @@ func getServerSettings(c *cli.Context) (clusters.ServerSettingsOpts, error) {
 		Interfaces:     []clusters.InterfaceOpts{interfaceOpts},
 		Volumes:        []clusters.VolumeOpts{volumeOpts},
 		Credentials:    &credentialOpts,
-		SecurityGroups: c.StringSlice("security-groups"),
+		SecurityGroups: getItemIDs(c, "security-groups"),
 		UserData:       StringPtrExcludeEmpty(c, "user-data"),
 	}
 	return serverSettings, nil
+}
+
+func getItemIDs(c *cli.Context, name string) []gcorecloud.ItemID {
+	ids := c.StringSlice(name)
+	res := make([]gcorecloud.ItemID, len(ids))
+	for i, id := range ids {
+		res[i] = gcorecloud.ItemID{ID: id}
+	}
+	return res
 }
 
 func StringPtrExcludeEmpty(c *cli.Context, name string) *string {

--- a/gcore/gpu/v3/clusters/requests.go
+++ b/gcore/gpu/v3/clusters/requests.go
@@ -118,7 +118,7 @@ type ServerCredentialsOpts struct {
 
 type ServerSettingsOpts struct {
 	Interfaces     []InterfaceOpts        `json:"interfaces"`
-	SecurityGroups []string               `json:"security_groups,omitempty"`
+	SecurityGroups []gcorecloud.ItemID    `json:"security_groups" validate:"omitempty,dive,uuid4"`
 	Volumes        []VolumeOpts           `json:"volumes"`
 	UserData       *string                `json:"user_data,omitempty"`
 	Credentials    *ServerCredentialsOpts `json:"credentials,omitempty"`

--- a/gcore/gpu/v3/clusters/results.go
+++ b/gcore/gpu/v3/clusters/results.go
@@ -3,6 +3,7 @@ package clusters
 import (
 	"encoding/json"
 	"fmt"
+
 	gcorecloud "github.com/G-Core/gcorelabscloud-go"
 	"github.com/G-Core/gcorelabscloud-go/gcore/task/v1/tasks"
 	"github.com/G-Core/gcorelabscloud-go/pagination"
@@ -154,11 +155,11 @@ type Volume struct {
 }
 
 type ClusterServerSettings struct {
-	Interfaces     []InterfaceUnion `json:"interfaces"`
-	SecurityGroups []string         `json:"security_groups"`
-	Volumes        []Volume         `json:"volumes"`
-	UserData       *string          `json:"user_data"`
-	SSHKeyName     *string          `json:"ssh_key_name"`
+	Interfaces     []InterfaceUnion      `json:"interfaces"`
+	SecurityGroups []gcorecloud.ItemName `json:"security_groups"`
+	Volumes        []Volume              `json:"volumes"`
+	UserData       *string               `json:"user_data"`
+	SSHKeyName     *string               `json:"ssh_key_name"`
 }
 
 type Cluster struct {

--- a/gcore/gpu/v3/servers/types.go
+++ b/gcore/gpu/v3/servers/types.go
@@ -2,22 +2,24 @@ package servers
 
 import (
 	"time"
+
+	gcorecloud "github.com/G-Core/gcorelabscloud-go"
 )
 
 // Server represents a server in a GPU cluster
 type Server struct {
-	ID             string    `json:"id"`
-	ImageID        *string   `json:"image_id"`
-	TaskID         *string   `json:"task_id"`
-	Flavor         string    `json:"flavor"`
-	KeypairID      *string   `json:"keypair_id"`
-	Name           string    `json:"name"`
-	Status         string    `json:"status"`
-	IPAddresses    []string  `json:"ip_addresses"`
-	SecurityGroups []string  `json:"security_groups"`
-	Tags           []Tag     `json:"tags"`
-	CreatedAt      time.Time `json:"created_at"`
-	UpdatedAt      time.Time `json:"updated_at"`
+	ID             string                `json:"id"`
+	ImageID        *string               `json:"image_id"`
+	TaskID         *string               `json:"task_id"`
+	Flavor         string                `json:"flavor"`
+	KeypairID      *string               `json:"keypair_id"`
+	Name           string                `json:"name"`
+	Status         string                `json:"status"`
+	IPAddresses    []string              `json:"ip_addresses"`
+	SecurityGroups []gcorecloud.ItemName `json:"security_groups"`
+	Tags           []Tag                 `json:"tags"`
+	CreatedAt      time.Time             `json:"created_at"`
+	UpdatedAt      time.Time             `json:"updated_at"`
 }
 
 // Tag represents a server tag

--- a/provider_client.go
+++ b/provider_client.go
@@ -22,7 +22,7 @@ import (
 // DefaultUserAgent is the default User-Agent string set in the request header.
 const DefaultUserAgent = "cloud-api-go-sdk/%s"
 
-var AppVersion = "0.22.2"
+var AppVersion = "0.22.3"
 
 // UserAgent represents a User-Agent header.
 type UserAgent struct {


### PR DESCRIPTION
## Description

Added support for recently introduced security groups in bare metal GPU clusters.

The v3 APIs changed from accepting and returning `[]string` to objects with `id` and `name` fields respectively.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have followed the style guidelines of this project
- [x] I have tested my changes with the latest version of Go

## Further comments

None