### PR TITLE
Remove password field from registry credential results

### DIFF
--- a/gcore/inference/v3/credentials/results.go
+++ b/gcore/inference/v3/credentials/results.go
@@ -8,7 +8,6 @@ type RegistryCredentials struct {
 	ProjectID   int    `json:"project_id"`
 	Name        string `json:"name"`
 	Username    string `json:"username"`
-	Password    string `json:"password"`
 	RegistryURL string `json:"registry_url"`
 }
 

--- a/gcore/inference/v3/credentials/testing/fixtures.go
+++ b/gcore/inference/v3/credentials/testing/fixtures.go
@@ -52,8 +52,8 @@ var (
 		ProjectID:   fake.ProjectID,
 		Name:        "docker-io",
 		Username:    "username",
-		Password:    "password",
 		RegistryURL: "registry.example.com",
 	}
-	CredsSlice = []credentials.RegistryCredentials{Creds1}
+	Creds1Password = "password"
+	CredsSlice     = []credentials.RegistryCredentials{Creds1}
 )

--- a/gcore/inference/v3/credentials/testing/requests_test.go
+++ b/gcore/inference/v3/credentials/testing/requests_test.go
@@ -106,7 +106,7 @@ func TestCreate(t *testing.T) {
 	options := credentials.CreateRegistryCredentialOpts{
 		Name:        Creds1.Name,
 		Username:    Creds1.Username,
-		Password:    Creds1.Password,
+		Password:    Creds1Password,
 		RegistryURL: Creds1.RegistryURL,
 	}
 
@@ -157,7 +157,7 @@ func TestUpdate(t *testing.T) {
 	client := fake.ServiceTokenClient("inferences", "v3")
 	opts := credentials.UpdateRegistryCredentialOpts{
 		Username:    Creds1.Username,
-		Password:    Creds1.Password,
+		Password:    Creds1Password,
 		RegistryURL: Creds1.RegistryURL,
 	}
 

--- a/provider_client.go
+++ b/provider_client.go
@@ -22,7 +22,7 @@ import (
 // DefaultUserAgent is the default User-Agent string set in the request header.
 const DefaultUserAgent = "cloud-api-go-sdk/%s"
 
-var AppVersion = "0.22.3"
+var AppVersion = "0.23.0"
 
 // UserAgent represents a User-Agent header.
 type UserAgent struct {


### PR DESCRIPTION
## Description
We removed `password` field from responses for all inference registry credentials handlers. This PR also revomes it from SDK structures.


Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

<!-- Put an "x" in the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have followed the style guidelines of this project
- [x] I have tested my changes with the latest version of Go

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... --> 