### PR TITLE
GCLOUD2-20380 Resolve SDK version from build info

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,15 +30,6 @@ jobs:
         with:
           go-version: 1.21
       -
-        name: Check tag version against AppVersion
-        run: |
-          TAG_VERSION=${GITHUB_REF#refs/tags/}
-          APP_VERSION=$(grep -oP 'var AppVersion = "\K[0-9]+\.[0-9]+\.[0-9]+' provider_client.go)
-          if [ "$TAG_VERSION" != "v$APP_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match AppVersion ($APP_VERSION)"
-            exit 1
-          fi
-      -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/provider_client.go
+++ b/provider_client.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"os"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -19,10 +20,31 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+func init() {
+	loadAppVersion()
+}
+
+func loadAppVersion() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	for _, dep := range info.Deps {
+		if dep.Path == "github.com/G-Core/gcorelabscloud-go" {
+			if dep.Replace != nil {
+				AppVersion = strings.TrimPrefix(dep.Replace.Version, "v")
+			} else {
+				AppVersion = strings.TrimPrefix(dep.Version, "v")
+			}
+			break
+		}
+	}
+}
+
 // DefaultUserAgent is the default User-Agent string set in the request header.
 const DefaultUserAgent = "cloud-api-go-sdk/%s"
 
-var AppVersion = "0.23.0"
+var AppVersion = "0"
 
 // UserAgent represents a User-Agent header.
 type UserAgent struct {


### PR DESCRIPTION
## Description

This PR is an idea how we can automatically resolve provider client's `AppVersion` at runtime based on [BuildInfo](https://pkg.go.dev/runtime/debug#BuildInfo) embedded at build time in each Go binary.

The change is 100% transparent to users and completely backwards compatible, while no longer requiring developers to remember to bump the version before cutting a new release with `git tag`.

Sample app I used to test it:

```go
package main

import (
	"fmt"

	gcorecloud "github.com/G-Core/gcorelabscloud-go"
)

func main() {
	fmt.Printf("SDK version: %v\n", gcorecloud.AppVersion)
}
```

go.mod
```
module test

go 1.24.5

replace github.com/G-Core/gcorelabscloud-go => github.com/gbernady/gcorelabscloud-go v0.22.4-0.20250805074854-c95eca7f4561

require github.com/G-Core/gcorelabscloud-go v0.22.3

require (
	github.com/go-playground/locales v0.13.0 // indirect
	github.com/go-playground/universal-translator v0.17.0 // indirect
	github.com/go-playground/validator/v10 v10.2.0 // indirect
	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
	github.com/ladydascalie/currency v1.5.0 // indirect
	github.com/leodido/go-urn v1.2.0 // indirect
	github.com/mitchellh/mapstructure v1.3.0 // indirect
	github.com/sirupsen/logrus v1.6.0 // indirect
	golang.org/x/sys v0.28.0 // indirect
)
```

## Type of change

- [x] Internal change / tech debt.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have followed the style guidelines of this project
- [x] I have tested my changes with the latest version of Go

## Further comments

None