### PR TITLE
GCLOUD2-20153  Refactor file share creation options to use TypeName instead of VolumeType and update related validation logic

### DIFF
--- a/client/file_shares/v1/file_shares/file_shares.go
+++ b/client/file_shares/v1/file_shares/file_shares.go
@@ -106,9 +106,9 @@ var fileShareCreateCommand = cli.Command{
 		}
 
 		// Validate if user provided network and subnet for vast, which are automatically set
-		// for vast, so they should not be provided by user.
+		// Validate if user provided network and subnet for 'vast' type, which are automatically set for 'vast', so they should not be provided by the user.
 		if typeName == "vast" && (c.String("network") != "" || c.String("subnet") != "") {
-			return cli.Exit("--network and/or --subnet should not be provided for vast type", 1)
+			return cli.Exit("--network and/or --subnet should not be provided for type-name=vast", 1)
 		}
 
 		opts := file_shares.CreateOpts{
@@ -120,7 +120,7 @@ var fileShareCreateCommand = cli.Command{
 			Tags:     tags,
 		}
 
-		// Validate if user provided network and subnet for standard, which are required.
+		// Validate if user provided network for 'standard' type, which is required.
 		if typeName == "standard" {
 			if c.String("network") == "" {
 				return cli.Exit("--network is required for type-name=standard (default)", 1)

--- a/client/file_shares/v1/file_shares/file_shares.go
+++ b/client/file_shares/v1/file_shares/file_shares.go
@@ -2,6 +2,7 @@ package file_shares
 
 import (
 	"fmt"
+
 	gcorecloud "github.com/G-Core/gcorelabscloud-go"
 	"github.com/G-Core/gcorelabscloud-go/client/file_shares/v1/client"
 	"github.com/G-Core/gcorelabscloud-go/client/flags"
@@ -111,16 +112,16 @@ var fileShareCreateCommand = cli.Command{
 		}
 
 		opts := file_shares.CreateOpts{
-			Name:       c.String("name"),
-			VolumeType: c.String("volume-type"),
-			Protocol:   c.String("protocol"),
-			Size:       c.Int("size"),
-			Access:     getAccessRules(c),
-			Tags:       tags,
+			Name:     c.String("name"),
+			TypeName: c.String("volume-type"), // Using TypeName field
+			Protocol: c.String("protocol"),
+			Size:     c.Int("size"),
+			Access:   getAccessRules(c),
+			Tags:     tags,
 		}
 
 		// Validate if user provided network and subnet for default_share_type, which are required.
-		if opts.VolumeType == "default_share_type" {
+		if opts.TypeName == "default_share_type" {
 			if c.String("network") == "" {
 				return cli.Exit("--network is required for volume-type=default_share_type (default)", 1)
 			}

--- a/client/file_shares/v1/file_shares/file_shares.go
+++ b/client/file_shares/v1/file_shares/file_shares.go
@@ -30,9 +30,9 @@ var fileShareCreateCommand = cli.Command{
 			Required: true,
 		},
 		&cli.StringFlag{
-			Name:     "volume-type",
-			Usage:    "File share volume type (default_share_type or vast_share_type)",
-			Value:    "default_share_type",
+			Name:     "type-name",
+			Usage:    "File share type name (standard or vast)",
+			Value:    "standard",
 			Required: false,
 		},
 		&cli.StringFlag{
@@ -49,7 +49,7 @@ var fileShareCreateCommand = cli.Command{
 		},
 		&cli.StringFlag{
 			Name:     "network",
-			Usage:    "File share network id (required for default_share_type)",
+			Usage:    "File share network id (required for standard type)",
 			Required: false,
 		},
 		&cli.StringFlag{
@@ -99,31 +99,31 @@ var fileShareCreateCommand = cli.Command{
 			}
 		}
 
-		// Validate volume-type
-		volumeType := c.String("volume-type")
-		if volumeType != "default_share_type" && volumeType != "vast_share_type" {
-			return cli.Exit("--volume-type must be either 'default_share_type' or 'vast_share_type'", 1)
+		// Validate type-name
+		typeName := c.String("type-name")
+		if typeName != "standard" && typeName != "vast" {
+			return cli.Exit("--type-name must be either 'standard' or 'vast'", 1)
 		}
 
-		// Validate if user provided network and subnet for vast_share_type, which are automatically set
-		// for vast_share_type, so they should not be provided by user.
-		if volumeType == "vast_share_type" && (c.String("network") != "" || c.String("subnet") != "") {
-			return cli.Exit("--network and/or --subnet should not be provided for vast_share_type", 1)
+		// Validate if user provided network and subnet for vast, which are automatically set
+		// for vast, so they should not be provided by user.
+		if typeName == "vast" && (c.String("network") != "" || c.String("subnet") != "") {
+			return cli.Exit("--network and/or --subnet should not be provided for vast type", 1)
 		}
 
 		opts := file_shares.CreateOpts{
 			Name:     c.String("name"),
-			TypeName: c.String("volume-type"), // Using TypeName field
+			TypeName: typeName,
 			Protocol: c.String("protocol"),
 			Size:     c.Int("size"),
 			Access:   getAccessRules(c),
 			Tags:     tags,
 		}
 
-		// Validate if user provided network and subnet for default_share_type, which are required.
-		if opts.TypeName == "default_share_type" {
+		// Validate if user provided network and subnet for standard, which are required.
+		if typeName == "standard" {
 			if c.String("network") == "" {
-				return cli.Exit("--network is required for volume-type=default_share_type (default)", 1)
+				return cli.Exit("--network is required for type-name=standard (default)", 1)
 			}
 			opts.Network = &file_shares.FileShareNetworkOpts{
 				NetworkID: c.String("network"),

--- a/gcore/file_share/v1/file_shares/requests.go
+++ b/gcore/file_share/v1/file_shares/requests.go
@@ -50,7 +50,7 @@ type CreateOpts struct {
 	Size     int                    `json:"size" required:"true" validate:"required,gt=0"`
 	Network  *FileShareNetworkOpts  `json:"network,omitempty" validate:"omitempty,dive"`
 	Access   []CreateAccessRuleOpts `json:"access,omitempty" validate:"dive"`
-	Tags     map[string]string      `json:"tags"`
+	Tags     map[string]string      `json:"tags,omitempty"`
 }
 
 // ToFileShareCreateMap builds a request body from CreateOpts.

--- a/gcore/file_share/v1/file_shares/requests.go
+++ b/gcore/file_share/v1/file_shares/requests.go
@@ -61,13 +61,13 @@ func (opts CreateOpts) ToFileShareCreateMap() (map[string]interface{}, error) {
 	return gcorecloud.BuildRequestBody(opts, "")
 }
 
-// Validate validates the CreateOpts structure.
+// Validate validates the CreateOpts structure and ensures required fields are present based on the type.
 func (opts CreateOpts) Validate() error {
 	if err := gcorecloud.Validate.Struct(opts); err != nil {
 		return gcorecloud.TranslateValidationError(err)
 	}
 	if (opts.TypeName == "" || opts.TypeName == "standard") && opts.Network == nil {
-		return errors.New("field Network is required for type_name standard")
+		return errors.New("field Network is required for TypeName 'standard'")
 	}
 	return nil
 }

--- a/gcore/file_share/v1/file_shares/requests.go
+++ b/gcore/file_share/v1/file_shares/requests.go
@@ -45,7 +45,7 @@ type CreateAccessRuleOpts struct {
 // CreateOpts represents options used to create a file share.
 type CreateOpts struct {
 	Name     string                 `json:"name" required:"true" validate:"required"`
-	TypeName string                 `json:"type_name,omitempty" validate:"omitempty,oneof=default_share_type vast_share_type"`
+	TypeName string                 `json:"type_name,omitempty" validate:"omitempty,oneof=standard vast"`
 	Protocol string                 `json:"protocol" required:"true" validate:"required,oneof=NFS"`
 	Size     int                    `json:"size" required:"true" validate:"required,gt=0"`
 	Network  *FileShareNetworkOpts  `json:"network,omitempty" validate:"omitempty,dive"`
@@ -66,8 +66,8 @@ func (opts CreateOpts) Validate() error {
 	if err := gcorecloud.Validate.Struct(opts); err != nil {
 		return gcorecloud.TranslateValidationError(err)
 	}
-	if (opts.TypeName == "" || opts.TypeName == "default_share_type") && opts.Network == nil {
-		return errors.New("field Network is required for type_name default_share_type")
+	if (opts.TypeName == "" || opts.TypeName == "standard") && opts.Network == nil {
+		return errors.New("field Network is required for type_name standard")
 	}
 	return nil
 }

--- a/gcore/file_share/v1/file_shares/requests.go
+++ b/gcore/file_share/v1/file_shares/requests.go
@@ -44,13 +44,13 @@ type CreateAccessRuleOpts struct {
 
 // CreateOpts represents options used to create a file share.
 type CreateOpts struct {
-	Name       string                 `json:"name" required:"true" validate:"required"`
-	VolumeType string                 `json:"volume_type,omitempty" validate:"omitempty,oneof=default_share_type vast_share_type"`
-	Protocol   string                 `json:"protocol" required:"true" validate:"required,oneof=NFS"`
-	Size       int                    `json:"size" required:"true" validate:"required,gt=0"`
-	Network    *FileShareNetworkOpts  `json:"network,omitempty" validate:"omitempty,dive"`
-	Access     []CreateAccessRuleOpts `json:"access,omitempty" validate:"dive"`
-	Tags       map[string]string      `json:"tags"`
+	Name     string                 `json:"name" required:"true" validate:"required"`
+	TypeName string                 `json:"type_name,omitempty" validate:"omitempty,oneof=default_share_type vast_share_type"`
+	Protocol string                 `json:"protocol" required:"true" validate:"required,oneof=NFS"`
+	Size     int                    `json:"size" required:"true" validate:"required,gt=0"`
+	Network  *FileShareNetworkOpts  `json:"network,omitempty" validate:"omitempty,dive"`
+	Access   []CreateAccessRuleOpts `json:"access,omitempty" validate:"dive"`
+	Tags     map[string]string      `json:"tags"`
 }
 
 // ToFileShareCreateMap builds a request body from CreateOpts.
@@ -61,13 +61,13 @@ func (opts CreateOpts) ToFileShareCreateMap() (map[string]interface{}, error) {
 	return gcorecloud.BuildRequestBody(opts, "")
 }
 
-// Validate
+// Validate validates the CreateOpts structure.
 func (opts CreateOpts) Validate() error {
 	if err := gcorecloud.Validate.Struct(opts); err != nil {
 		return gcorecloud.TranslateValidationError(err)
 	}
-	if (opts.VolumeType == "" || opts.VolumeType == "default_share_type") && opts.Network == nil {
-		return errors.New("field Network is required for volume_type default_share_type")
+	if (opts.TypeName == "" || opts.TypeName == "default_share_type") && opts.Network == nil {
+		return errors.New("field Network is required for type_name default_share_type")
 	}
 	return nil
 }

--- a/gcore/file_share/v1/file_shares/results.go
+++ b/gcore/file_share/v1/file_shares/results.go
@@ -110,7 +110,6 @@ type FileShare struct {
 	Region           string                          `json:"region"`
 	Metadata         map[string]interface{}          `json:"metadata"`
 	Tags             []Tag                           `json:"tags"`
-	VolumeType       string                          `json:"volume_type"`
 }
 
 // Validate validates the FileShare structure.


### PR DESCRIPTION
⚠️ This is a breaking change - Any existing code that was using the VolumeType field will need to be updated to use TypeName instead.

# Remove volume_type field from File Shares

## Description

This PR removes the `volume_type` field from File Shares and consolidates functionality to use only `type_name`. This change eliminates redundancy where both `volume_type` and `type_name` were representing the same information.

**Changes made:**
- Removed `VolumeType` field from `CreateOpts` struct
- Removed `VolumeType` field from `FileShare` struct  
- Simplified validation logic to use only `TypeName`
- Updated validation to use correct API values: `standard` and `vast`
- Updated CLI to use `--type-name` flag directly with API values
- Removed all backward compatibility/mapping logic
- Updated all business logic to use `type_name` exclusively

**Files changed:**
```
 client/file_shares/v1/file_shares/file_shares.go | 25 +++++++++++++++----------
 gcore/file_share/v1/file_shares/requests.go      | 15 ++++++---------
 gcore/file_share/v1/file_shares/results.go       |  1 -
 3 files changed, 21 insertions(+), 20 deletions(-)
```

**API Value Mapping:**
- CLI/SDK now uses direct API values instead of SDK-specific values
- `standard` (was `default_share_type`) - Standard file share requiring network
- `vast` (was `vast_share_type`) - VAST file share with auto-assigned network

**Motivation:**
- Eliminates confusion between two fields representing the same data
- Simplifies the codebase by removing redundant fields
- Aligns with the actual API values and design
- Removes unnecessary mapping/compatibility layers

Fixes #(issue)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have tested my changes with real API calls
- [x] I have followed the style guidelines of this project
- [x] I have tested my changes with the latest version of Go
- [x] I have verified the CLI works with new parameters

## Breaking Changes

⚠️ **This is a breaking change for both API usage and CLI interface.**

### API/SDK Migration Guide

**Before:**
```go
// Using VolumeType field (now removed)
opts := file_shares.CreateOpts{
    Name:       "my-share",
    VolumeType: "default_share_type",
    Protocol:   "NFS",
    Size:       100,
}

// Accessing VolumeType field in responses (now removed)
fmt.Println(fileShare.VolumeType)
```

**After:**
```go
// Use TypeName field with API values
opts := file_shares.CreateOpts{
    Name:     "my-share",
    TypeName: "standard",  // Note: API values changed
    Protocol: "NFS",
    Size:     100,
}

// Access TypeName field in responses
fmt.Println(fileShare.TypeName)
```

### CLI Interface Changes

The CLI interface has been updated to use the new API values directly:

**Before:**
```bash
# Old CLI interface (no longer works)
gcoreclient share create --name my-share --volume-type default_share_type --size 100
```

**After:**
```bash
# New CLI interface with direct API values
gcoreclient share create --name my-share --type-name standard --size 100
gcoreclient share create --name my-share --type-name vast --size 100
```

### Value Mapping

| Old SDK Value | New API Value | Description |
|---|---|---|
| `default_share_type` | `standard` | Standard file share (requires network) |
| `vast_share_type` | `vast` | VAST file share (network auto-assigned) |

## Testing

- [x] Verified compilation of affected packages
- [x] Confirmed no linting errors
- [x] Validated CLI with new `--type-name` parameter
- [x] **Tested with real API calls** - confirmed file share creation works
- [x] Verified correct `type_name` values in API requests and responses
- [x] Checked validation for both valid and invalid type names
- [x] Verified network requirement validation for `standard` type

## Further comments

This change not only removes the redundant `volume_type` field but also aligns the SDK with the actual API values. The previous SDK was using internal values that required mapping to API values, which added unnecessary complexity.

The breaking changes ensure that:
1. Users work directly with API values, improving clarity
2. No hidden mapping logic that could cause confusion
3. CLI and SDK are fully aligned with the backend API
4. Cleaner, more maintainable codebase

While this requires users to update their code, it provides a much cleaner and more reliable interface that directly matches the API specification.
