### PR TITLE
MKAAS-1623 Add managed_by opt to list gpu clusters

### DIFF
--- a/client/gpu/v3/clusters/clusters.go
+++ b/client/gpu/v3/clusters/clusters.go
@@ -483,6 +483,15 @@ func getVolumeOpts(c *cli.Context) (clusters.VolumeOpts, error) {
 	return volume, nil
 }
 
+func listClustersFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:  "managed-by",
+			Usage: "the entity responsible for managing the cluster",
+		},
+	}
+}
+
 func createClusterFlags() []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
@@ -628,7 +637,9 @@ func listClustersAction(c *cli.Context, newClient func(*cli.Context) (*gcoreclou
 		_ = cli.ShowAppHelp(c)
 		return cli.Exit(err, 1)
 	}
-	opts := &clusters.ListOpts{}
+	opts := &clusters.ListOpts{
+		ManagedBy: clusters.ManagedByOpt(c.String("managed-by")),
+	}
 	clusterList, err := clusters.ListAll(gpuClient, opts)
 	if err != nil {
 		return cli.Exit(err, 1)
@@ -687,6 +698,7 @@ func BaremetalCommands() *cli.Command {
 				Description: "List all baremetal GPU clusters",
 				Category:    "clusters",
 				ArgsUsage:   " ",
+				Flags:       listClustersFlags(),
 				Action:      listBaremetalClustersAction,
 			},
 		},

--- a/gcore/gpu/v3/clusters/requests.go
+++ b/gcore/gpu/v3/clusters/requests.go
@@ -72,7 +72,7 @@ type ListClustersOptsBuilder interface {
 type ListOpts struct {
 	Limit     int          `q:"limit" validate:"omitempty,gt=0"`
 	Offset    int          `q:"offset" validate:"omitempty,gte=0"`
-	ManagedBy ManagedByOpt `q:"managed_by" validate:"omitempty"`
+	ManagedBy ManagedByOpt `q:"managed_by" validate:"omitempty,oneof=k8s user"`
 }
 
 // ToListClustersQuery formats a ListOpts into a query string.

--- a/gcore/gpu/v3/clusters/requests.go
+++ b/gcore/gpu/v3/clusters/requests.go
@@ -70,8 +70,9 @@ type ListClustersOptsBuilder interface {
 
 // ListOpts allows the filtering and sorting of paginated collections through the API.
 type ListOpts struct {
-	Limit  int `q:"limit" validate:"omitempty,gt=0"`
-	Offset int `q:"offset" validate:"omitempty,gte=0"`
+	Limit     int          `q:"limit" validate:"omitempty,gt=0"`
+	Offset    int          `q:"offset" validate:"omitempty,gte=0"`
+	ManagedBy ManagedByOpt `q:"managed_by" validate:"omitempty"`
 }
 
 // ToListClustersQuery formats a ListOpts into a query string.

--- a/gcore/gpu/v3/clusters/types.go
+++ b/gcore/gpu/v3/clusters/types.go
@@ -10,10 +10,9 @@ type VolumeSource string
 type VolumeType string
 type ClusterStatusType string
 type FloatingIPSource string
-
 type InterfaceType string
-
 type ClusterAction string
+type ManagedByOpt string
 
 const (
 	IPv4IPFamilyType      IPFamilyType = "ipv4"
@@ -51,6 +50,9 @@ const (
 	SoftRebootClusterAction ClusterAction = "soft_reboot"
 	ResizeClusterAction     ClusterAction = "resize"
 	UpdateTagsClusterAction ClusterAction = "update_tags"
+
+	ManagedByK8s  ManagedByOpt = "k8s"
+	ManagedByUser ManagedByOpt = "user"
 )
 
 func (it *IPFamilyType) IsValid() error {

--- a/pagination/pager.go
+++ b/pagination/pager.go
@@ -134,6 +134,10 @@ func (p Pager) EachPage(handler func(Page) (bool, error)) error {
 // AllPages returns all the pages from a `List` operation in a single page,
 // allowing the user to retrieve all the pages at once.
 func (p Pager) AllPages() (Page, error) {
+	if p.Err != nil {
+		return nil, p.Err
+	}
+
 	// pagesSlice holds all the pages until they get converted into as Page Body.
 	var pagesSlice []interface{}
 	// body will contain the final concatenated Page body.


### PR DESCRIPTION
## Description

Added `managed_by` query param to GPU clusters list opts. Optional. Default behavior unchanged.

Examples:

```sh
# list clusters created by users
gcoreclient api-token gpu baremetal clusters list
gcoreclient api-token gpu baremetal clusters list --managed-by=user

# list clusters created by managed k8s
gcoreclient api-token gpu baremetal clusters list --managed-by=k8s
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have followed the style guidelines of this project
- [x] I have tested my changes with the latest version of Go

## Further comments

None