### PR TITLE
GCLOUD2-20099 Add Baremetal GPU cluster creation

### DIFF
--- a/client/gpu/v3/clusters/clusters.go
+++ b/client/gpu/v3/clusters/clusters.go
@@ -364,6 +364,7 @@ func createClusterAction(c *cli.Context, newClient func(*cli.Context) (*gcoreclo
 			Name:            c.String("name"),
 			Flavor:          c.String("flavor"),
 			ServersCount:    c.Int("servers-count"),
+			ImageID:         c.String("image-id"),
 			Tags:            tags,
 			ServersSettings: serverSettings,
 		}
@@ -573,12 +574,7 @@ func createClusterVolumeFlags() []cli.Flag {
 	}
 }
 
-func createVirtualClusterFlags() []cli.Flag {
-	// Virtual cluster flags include both baremetal cluster flags and volume flags
-	return append(createBaremetalClusterFlags(), createClusterVolumeFlags()...)
-}
-
-func createBaremetalClusterFlags() []cli.Flag {
+func createCommonClusterFlags() []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
 			Name:     "name",
@@ -684,6 +680,22 @@ func createBaremetalClusterFlags() []cli.Flag {
 			Required: false,
 		},
 	}
+}
+
+func createVirtualClusterFlags() []cli.Flag {
+	// Virtual cluster flags include volume flags besides common flags
+	return append(createCommonClusterFlags(), createClusterVolumeFlags()...)
+}
+
+func createBaremetalClusterFlags() []cli.Flag {
+	// Baremetal cluster flags include the image-id flag besides common flags
+	return append(createCommonClusterFlags(),
+		&cli.StringFlag{
+			Name:     "image-id",
+			Aliases:  []string{"i"},
+			Usage:    "image ID for the servers in the cluster",
+			Required: true,
+		})
 }
 
 // listClustersAction handles the common logic for listing both virtual and baremetal clusters

--- a/client/gpu/v3/clusters/clusters.go
+++ b/client/gpu/v3/clusters/clusters.go
@@ -345,10 +345,13 @@ func createClusterAction(c *cli.Context, gpuType string, newClient func(*cli.Con
 		return cli.Exit("`user-data` cannot be used together with `server-username` or `server-password`", 1)
 	}
 
-	tags, err := utils.StringSliceToTags(c.StringSlice("tags"))
-	if err != nil {
-		_ = cli.ShowCommandHelp(c, "create")
-		return cli.Exit(err, 1)
+	var tags map[string]string
+	if c.IsSet("tags") {
+		tags, err = utils.StringSliceToTags(c.StringSlice("tags"))
+		if err != nil {
+			_ = cli.ShowCommandHelp(c, "create")
+			return cli.Exit(err, 1)
+		}
 	}
 	// Validate servers count
 	if c.Int("servers-count") <= 0 {
@@ -551,7 +554,7 @@ func createClusterVolumeFlags() []cli.Flag {
 		},
 		&cli.IntFlag{
 			Name:     "volume-size",
-			Usage:    "size of the volume",
+			Usage:    "size of the volume in GB",
 			Required: true,
 		},
 		&cli.StringFlag{
@@ -562,6 +565,10 @@ func createClusterVolumeFlags() []cli.Flag {
 		&cli.StringSliceFlag{
 			Name:  "volume-tags",
 			Usage: "tags for the volume",
+		},
+		&cli.BoolFlag{
+			Name:  "volume-delete-on-termination",
+			Usage: "delete volume on termination",
 		},
 		&cli.GenericFlag{
 			Name:    "volume-type",
@@ -630,10 +637,6 @@ func createCommonClusterFlags() []cli.Flag {
 			Aliases:  []string{"k"},
 			Usage:    "(ssh) keypair name for the servers in the cluster",
 			Required: false,
-		},
-		&cli.BoolFlag{
-			Name:  "volume-delete-on-termination",
-			Usage: "delete volume on termination",
 		},
 		&cli.GenericFlag{
 			Name:    "interface-type",

--- a/client/gpu/v3/clusters/clusters.go
+++ b/client/gpu/v3/clusters/clusters.go
@@ -762,8 +762,8 @@ func BaremetalCommands() *cli.Command {
 			},
 			{
 				Name:        "create",
-				Usage:       "Create a new virtual GPU cluster",
-				Description: "Create a new virtual GPU cluster with the specified options",
+				Usage:       "Create a new baremetal GPU cluster",
+				Description: "Create a new baremetal GPU cluster with the specified options",
 				Category:    "clusters",
 				Flags:       append(createBaremetalClusterFlags(), flags.WaitCommandFlags...),
 				Action:      createBaremetalClusterAction,

--- a/client/gpu/v3/clusters/clusters.go
+++ b/client/gpu/v3/clusters/clusters.go
@@ -124,6 +124,10 @@ func updateTagsVirtualClusterAction(c *cli.Context) error {
 	return updateTagsClusterAction(c, client.NewGPUVirtualClientV3)
 }
 
+func updateTagsBaremetalClusterAction(c *cli.Context) error {
+	return updateTagsClusterAction(c, client.NewGPUBaremetalClientV3)
+}
+
 func softRebootClusterAction(c *cli.Context, newClient func(ctx *cli.Context) (*gcorecloud.ServiceClient, error)) error {
 	clusterID := c.Args().First()
 	if clusterID == "" {
@@ -776,6 +780,28 @@ func BaremetalCommands() *cli.Command {
 				ArgsUsage:   " ",
 				Flags:       listClustersFlags(),
 				Action:      listBaremetalClustersAction,
+			},
+			{
+				Name:        "updatetags",
+				Usage:       "Update tags of baremetal GPU cluster",
+				Description: "Updates the tags of specific baremetal GPU cluster",
+				Category:    "clusters",
+				ArgsUsage:   "<cluster_id>",
+				Action:      updateTagsBaremetalClusterAction,
+				Flags: append([]cli.Flag{
+					&cli.StringSliceFlag{
+						Name:     "tags",
+						Aliases:  []string{"t"},
+						Usage:    "cluster key-value tags. Example: --tags key1=value1 --tags key2=value2",
+						Required: false,
+					},
+					&cli.StringSliceFlag{
+						Name:     "remove-tags",
+						Aliases:  []string{"rt"},
+						Usage:    "cluster tag names. Example: --remove-tags key1 --remove-tags key2",
+						Required: false,
+					},
+				}, flags.WaitCommandFlags...),
 			},
 		},
 	}

--- a/gcore/gpu/v3/clusters/requests.go
+++ b/gcore/gpu/v3/clusters/requests.go
@@ -209,6 +209,7 @@ func (opts CreateClusterOpts) ToCreateClusterMap() (map[string]interface{}, erro
 type CreateBaremetalClusterOpts struct {
 	Name            string                      `json:"name" validate:"required"`
 	Flavor          string                      `json:"flavor" validate:"required"`
+	ImageID         string                      `json:"image_id" validate:"required"`
 	Tags            map[string]string           `json:"tags,omitempty"`
 	ServersCount    int                         `json:"servers_count" validate:"required"`
 	ServersSettings BaremetalServerSettingsOpts `json:"servers_settings,omitempty"`

--- a/gcore/gpu/v3/clusters/requests.go
+++ b/gcore/gpu/v3/clusters/requests.go
@@ -125,6 +125,13 @@ type ServerSettingsOpts struct {
 	Credentials    *ServerCredentialsOpts `json:"credentials,omitempty"`
 }
 
+type BaremetalServerSettingsOpts struct {
+	Interfaces     []InterfaceOpts        `json:"interfaces"`
+	SecurityGroups []gcorecloud.ItemID    `json:"security_groups" validate:"omitempty,dive,uuid4"`
+	UserData       *string                `json:"user_data,omitempty"`
+	Credentials    *ServerCredentialsOpts `json:"credentials,omitempty"`
+}
+
 // VolumeOpts represents options used to create a volume.
 type VolumeOpts struct {
 	Source              VolumeSource      `json:"source" validate:"required,enum"`
@@ -188,6 +195,32 @@ func (opts CreateClusterOpts) Validate() error {
 }
 
 func (opts CreateClusterOpts) ToCreateClusterMap() (map[string]interface{}, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
+	mp, err := gcorecloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return mp, nil
+}
+
+// CreateBaremetalClusterOpts allows extensions to add parameters to create baremetal cluster options.
+type CreateBaremetalClusterOpts struct {
+	Name            string                      `json:"name" validate:"required"`
+	Flavor          string                      `json:"flavor" validate:"required"`
+	Tags            map[string]string           `json:"tags,omitempty"`
+	ServersCount    int                         `json:"servers_count" validate:"required"`
+	ServersSettings BaremetalServerSettingsOpts `json:"servers_settings,omitempty"`
+}
+
+// Validate checks if the provided options are valid.
+func (opts CreateBaremetalClusterOpts) Validate() error {
+	return gcorecloud.ValidateStruct(opts)
+}
+
+// ToCreateClusterMap builds a request body from CreateBaremetalClusterOpts.
+func (opts CreateBaremetalClusterOpts) ToCreateClusterMap() (map[string]interface{}, error) {
 	if err := opts.Validate(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

This PR performs the following changes:
- decouples Baremetal and Virtual GPU cluster creation in the SDK, by creating new Opts types for Baremetal GPU clusters (require an `image_id`as input and don't expect to receive `volumes` inside `server_settings`).
- adds a command for creating Baremetal GPU clusters: `gcoreclient gpu baremetal cluster create`
- removes the flag `delete-all-volumes` from the `delete` command for Baremetal GPU clusters
- adds a command for updating tags of Baremetal GPU clusters: `gcoreclient gpu baremetal cluster updatetags`

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!-- Put an "x" in the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have followed the style guidelines of this project
- [x] I have tested my changes with the latest version of Go

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... --> 