### PR TITLE
Fix subnet EnableDHCP to use *bool for correct omitempty behavior

### DIFF
--- a/client/subnets/v1/subnets/subnets.go
+++ b/client/subnets/v1/subnets/subnets.go
@@ -305,9 +305,15 @@ var subnetCreateCommand = cli.Command{
 			return cli.NewExitError(err, 1)
 		}
 
+		var enableDHCP *bool
+		if c.IsSet("enable-dhcp") {
+			v := c.Bool("enable-dhcp")
+			enableDHCP = &v
+		}
+
 		opts := subnets.CreateOpts{
 			Name:                   c.String("name"),
-			EnableDHCP:             c.Bool("enable-dhcp"),
+			EnableDHCP:             enableDHCP,
 			CIDR:                   *cidr,
 			NetworkID:              c.String("network-id"),
 			ConnectToNetworkRouter: c.Bool("connect-to-router"),

--- a/gcore/subnet/v1/subnets/requests.go
+++ b/gcore/subnet/v1/subnets/requests.go
@@ -52,7 +52,7 @@ type HostRoute struct {
 // GatewayIP must be null in json because an empty key creates a gateway in the neutron API.
 type CreateOpts struct {
 	Name                   string            `json:"name" required:"true"`
-	EnableDHCP             bool              `json:"enable_dhcp,omitempty"`
+	EnableDHCP             *bool             `json:"enable_dhcp,omitempty"`
 	CIDR                   gcorecloud.CIDR   `json:"cidr" required:"true"`
 	NetworkID              string            `json:"network_id" required:"true"`
 	ConnectToNetworkRouter bool              `json:"connect_to_network_router"`
@@ -114,7 +114,7 @@ type UpdateOpts struct {
 	Name           string      `json:"name,omitempty"`
 	DNSNameservers []net.IP    `json:"dns_nameservers"`
 	HostRoutes     []HostRoute `json:"host_routes"`
-	EnableDHCP     bool        `json:"enable_dhcp"`
+	EnableDHCP     *bool       `json:"enable_dhcp,omitempty"`
 	GatewayIP      *net.IP     `json:"gateway_ip"`
 }
 

--- a/gcore/subnet/v1/subnets/testing/fixtures.go
+++ b/gcore/subnet/v1/subnets/testing/fixtures.go
@@ -108,8 +108,7 @@ const UpdateRequestNoGW = `
  	"name": "subnet",
  	"gateway_ip": null,
     "dns_nameservers": null,
-    "host_routes": null,
-    "enable_dhcp": false
+    "host_routes": null
 }
 `
 
@@ -124,7 +123,6 @@ const UpdateRequestGW = `
 
 const UpdateRequestNoData = `
 {
-    "enable_dhcp": false,
     "dns_nameservers": [],
     "host_routes": [],
     "gateway_ip": null

--- a/gcore/subnet/v1/subnets/testing/options_test.go
+++ b/gcore/subnet/v1/subnets/testing/options_test.go
@@ -9,10 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func boolPtr(v bool) *bool { return &v }
+
 func TestCreateOptsNoGW(t *testing.T) {
 	options := subnets.CreateOpts{
 		Name:                   Subnet1.Name,
-		EnableDHCP:             true,
+		EnableDHCP:             boolPtr(true),
 		CIDR:                   Subnet1.CIDR,
 		NetworkID:              Subnet1.NetworkID,
 		ConnectToNetworkRouter: true,
@@ -28,7 +30,7 @@ func TestCreateOptsGW(t *testing.T) {
 	gw := net.IP{}
 	options := subnets.CreateOpts{
 		Name:                   Subnet1.Name,
-		EnableDHCP:             true,
+		EnableDHCP:             boolPtr(true),
 		CIDR:                   Subnet1.CIDR,
 		NetworkID:              Subnet1.NetworkID,
 		ConnectToNetworkRouter: true,

--- a/gcore/subnet/v1/subnets/testing/requests_test.go
+++ b/gcore/subnet/v1/subnets/testing/requests_test.go
@@ -163,7 +163,7 @@ func TestCreateNoGW(t *testing.T) {
 
 	options := subnets.CreateOpts{
 		Name:                   Subnet1.Name,
-		EnableDHCP:             true,
+		EnableDHCP:             boolPtr(true),
 		CIDR:                   Subnet1.CIDR,
 		NetworkID:              Subnet1.NetworkID,
 		ConnectToNetworkRouter: true,
@@ -197,7 +197,7 @@ func TestCreateGW(t *testing.T) {
 	gw := net.IP{}
 	options := subnets.CreateOpts{
 		Name:                   Subnet1.Name,
-		EnableDHCP:             true,
+		EnableDHCP:             boolPtr(true),
 		CIDR:                   Subnet1.CIDR,
 		NetworkID:              Subnet1.NetworkID,
 		ConnectToNetworkRouter: true,
@@ -297,7 +297,7 @@ func TestUpdateGW(t *testing.T) {
 	opts := subnets.UpdateOpts{
 		Name:       Subnet1.Name,
 		GatewayIP:  &gw,
-		EnableDHCP: true,
+		EnableDHCP: boolPtr(true),
 	}
 
 	ct, err := subnets.Update(client, Subnet1.ID, opts).Extract()


### PR DESCRIPTION
## Summary
- Change `EnableDHCP` from `bool` to `*bool` in `CreateOpts` and `UpdateOpts` so that `omitempty` can distinguish between "not set" (nil, omitted from JSON, API applies default) and "explicitly set to false".
- Update the CLI client to only set the pointer when `--enable-dhcp` is explicitly provided.
- Update test fixtures and expectations accordingly.

## Test plan
- [x] `go test ./gcore/subnet/v1/subnets/testing/...` passes
- [x] `go build ./gcore/subnet/... && go build ./client/subnets/...` compiles