### PR TITLE
GCLOUD2-25466 use PATCH instead of PUT in projects.Update

### DIFF
--- a/gcore/project/v1/projects/requests.go
+++ b/gcore/project/v1/projects/requests.go
@@ -81,7 +81,7 @@ func Update(c *gcorecloud.ServiceClient, id int, opts UpdateOptsBuilder) (r Upda
 		r.Err = err
 		return
 	}
-	_, r.Err = c.Put(updateURL(c, id), b, &r.Body, &gcorecloud.RequestOpts{ // nolint
+	_, r.Err = c.Patch(updateURL(c, id), b, &r.Body, &gcorecloud.RequestOpts{ // nolint
 		OkCodes: []int{200, 201},
 	})
 	return

--- a/gcore/project/v1/projects/testing/requests_test.go
+++ b/gcore/project/v1/projects/testing/requests_test.go
@@ -164,7 +164,7 @@ func TestUpdate(t *testing.T) {
 	testURL := prepareGetTestURL(Project1.ID)
 
 	th.Mux.HandleFunc(testURL, func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "PUT")
+		th.TestMethod(t, r, "PATCH")
 		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 		th.TestHeader(t, r, "Content-Type", "application/json")
 		th.TestHeader(t, r, "Accept", "application/json")


### PR DESCRIPTION
## Summary
- `PUT /cloud/v1/projects/{project_id}` is retiring on **2026-06-11** (see GCLOUD2-23608). The endpoint accepts an identical body via PATCH.
- Switch `project/v1/projects.Update()` to call `c.Patch` so this SDK keeps working after the sunset date — no body or signature changes.
- Updated the corresponding `TestUpdate` HTTP-method assertion.

## Test plan
- [x] `go test ./gcore/project/v1/projects/...` passes
- [x] End-to-end : built `gcoreclient` from this branch, ran `project create` → `project update -d` → `project delete`. Debug output confirms `PATCH /cloud/v1/projects/<id>` returning `200 OK`.