### PR TITLE
MKAAS-1729 Bump github.com/ladydascalie/currency to v1.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/imdario/mergo v0.3.9
 	github.com/json-iterator/go v1.1.9 // indirect
 	github.com/kr/pretty v0.2.0 // indirect
-	github.com/ladydascalie/currency v1.5.0
+	github.com/ladydascalie/currency v1.8.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.0
 	github.com/olekukonko/tablewriter v0.0.4
@@ -29,7 +29,10 @@ require (
 	k8s.io/client-go v0.18.14
 )
 
-require github.com/AlekSi/pointer v1.2.0
+require (
+	github.com/AlekSi/pointer v1.2.0
+	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
+)
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
@@ -53,7 +56,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/apimachinery v0.18.14 // indirect
 	k8s.io/klog v1.0.0 // indirect
-	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89 // indirect
 	sigs.k8s.io/structured-merge-diff/v3 v3.0.0 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/ladydascalie/currency v1.5.0 h1:PFHHDWX1EU8mUCagpOwI33Z+DtqACLbO7SEbcbvNZSE=
-github.com/ladydascalie/currency v1.5.0/go.mod h1:5mvojKcR6tibOZcEnBy6JYiPGi7Vts7J1MHOeHY5n1E=
+github.com/ladydascalie/currency v1.8.0 h1:dGPliIMwQ5OogcQRHSj8Teau8QuWO3s5E9PJAuW9ysI=
+github.com/ladydascalie/currency v1.8.0/go.mod h1:C9eil8e6tthhBb5yhwoH1U0LT5hm1BP/g+v/V82KYjY=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=


### PR DESCRIPTION
## Description

1. Bumped `github.com/ladydascalie/currency` to v1.8.0 to stop it from being reported as having invalid license:

```
Not allowed license  found for library github.com/ladydascalie/currency
```

2. Ran `go mod tidy`, which reclassified `k8s.io/utils` as a direct dependency. Most probably a leftover from one of the earlier changes in the repo.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have followed the style guidelines of this project
- [x] I have tested my changes with the latest version of Go

## Further comments