### PR TITLE
MKAAS-1648 Rebuild gpu cluster servers with updated cluster settings

### DIFF
--- a/client/gpu/v3/clusters/clusters.go
+++ b/client/gpu/v3/clusters/clusters.go
@@ -282,6 +282,72 @@ func updateTagsClusterAction(c *cli.Context, newClient func(ctx *cli.Context) (*
 		waitForClusterOperation(gpuClient, clusterID))
 }
 
+func updateServersSettingsAction(c *cli.Context, newClient func(*cli.Context) (*gcorecloud.ServiceClient, error)) error {
+	clusterID := c.Args().First()
+	if clusterID == "" {
+		_ = cli.ShowCommandHelp(c, "update-settings")
+		return cli.Exit("cluster ID is required", 1)
+	}
+
+	if !c.IsSet("image-id") && !c.IsSet("ssh-key-name") && !c.IsSet("user-data") {
+		_ = cli.ShowCommandHelp(c, "update-settings")
+		return cli.Exit("at least one of `image-id`, `ssh-key-name`, or `user-data` must be specified", 1)
+	}
+
+	gpuClient, err := newClient(c)
+	if err != nil {
+		_ = cli.ShowAppHelp(c)
+		return cli.Exit(err, 1)
+	}
+
+	opts := clusters.UpdateServersSettingsOpts{
+		ImageID: StringPtrExcludeEmpty(c, "image-id"),
+	}
+	if c.IsSet("ssh-key-name") || c.IsSet("user-data") {
+		serverSettings := &clusters.UpdatedServerSettings{}
+		if c.IsSet("ssh-key-name") {
+			serverSettings.Credentials = &clusters.UpdatedServerCredentials{
+				SSHKeyName: c.String("ssh-key-name"),
+			}
+		}
+		serverSettings.UserData = StringPtrExcludeEmpty(c, "user-data")
+		opts.ServersSettings = serverSettings
+	}
+
+	result := clusters.UpdateServersSettings(gpuClient, clusterID, opts)
+	if result.Err != nil {
+		return cli.Exit(result.Err, 1)
+	}
+
+	utils.ShowResults(result.Body, c.String("format"))
+	return nil
+}
+
+func updateServersSettingsVirtualClusterAction(c *cli.Context) error {
+	return updateServersSettingsAction(c, client.NewGPUVirtualClientV3)
+}
+
+func updateServersSettingsBaremetalClusterAction(c *cli.Context) error {
+	return updateServersSettingsAction(c, client.NewGPUBaremetalClientV3)
+}
+
+func updateServersSettingsFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:  "image-id",
+			Usage: "new image ID for cluster servers",
+		},
+		&cli.StringFlag{
+			Name:  "ssh-key-name",
+			Usage: "new SSH key name for server credentials",
+		},
+		&cli.StringFlag{
+			Name:  "user-data",
+			Usage: "new user data for servers (base64 encoded)",
+		},
+	}
+}
+
 func waitForClusterOperation(gpuClient *gcorecloud.ServiceClient, clusterID string) func(task tasks.TaskID) (interface{}, error) {
 	return func(task tasks.TaskID) (interface{}, error) {
 		cluster, err := clusters.Get(gpuClient, clusterID).Extract()
@@ -804,6 +870,15 @@ func BaremetalCommands() *cli.Command {
 					},
 				}, flags.WaitCommandFlags...),
 			},
+			{
+				Name:        "update-settings",
+				Usage:       "Update server settings of baremetal GPU cluster",
+				Description: "Update server settings (image, SSH key, user data) for a baremetal GPU cluster",
+				Category:    "clusters",
+				ArgsUsage:   "<cluster_id>",
+				Flags:       updateServersSettingsFlags(),
+				Action:      updateServersSettingsBaremetalClusterAction,
+			},
 		},
 	}
 }
@@ -938,6 +1013,15 @@ func VirtualCommands() *cli.Command {
 						Required: false,
 					},
 				}, flags.WaitCommandFlags...),
+			},
+			{
+				Name:        "update-settings",
+				Usage:       "Update server settings of virtual GPU cluster",
+				Description: "Update server settings (image, SSH key, user data) for a virtual GPU cluster",
+				Category:    "clusters",
+				ArgsUsage:   "<cluster_id>",
+				Flags:       updateServersSettingsFlags(),
+				Action:      updateServersSettingsVirtualClusterAction,
 			},
 		},
 	}

--- a/client/gpu/v3/servers/servers.go
+++ b/client/gpu/v3/servers/servers.go
@@ -96,6 +96,53 @@ func deleteVirtualServerAction(c *cli.Context) error {
 	return deleteServerAction(c, "virtual", client.NewGPUVirtualClientV3)
 }
 
+func rebuildServerAction(c *cli.Context, newClient func(*cli.Context) (*gcorecloud.ServiceClient, error)) error {
+	clusterID := c.Args().First()
+	if clusterID == "" {
+		_ = cli.ShowCommandHelp(c, "rebuild")
+		return cli.Exit("cluster ID is required", 1)
+	}
+
+	serverID := c.Args().Get(1)
+	if serverID == "" {
+		_ = cli.ShowCommandHelp(c, "rebuild")
+		return cli.Exit("server ID is required", 1)
+	}
+
+	gpuClient, err := newClient(c)
+	if err != nil {
+		_ = cli.ShowAppHelp(c)
+		return cli.Exit(err, 1)
+	}
+
+	results, err := servers.Rebuild(gpuClient, clusterID, serverID).Extract()
+	if err != nil {
+		return cli.Exit(err, 1)
+	}
+
+	tc, err := tasksclient.NewTaskClientV1(c)
+	if err != nil {
+		_ = cli.ShowAppHelp(c)
+		return cli.Exit(err, 1)
+	}
+
+	return utils.WaitTaskAndShowResult(c, tc, results, false, func(task tasks.TaskID) (interface{}, error) {
+		servers, err := servers.ListAll(gpuClient, clusterID, nil)
+		if err != nil {
+			return nil, err
+		}
+		return servers, nil
+	})
+}
+
+func rebuildBaremetalServerAction(c *cli.Context) error {
+	return rebuildServerAction(c, client.NewGPUBaremetalClientV3)
+}
+
+func rebuildVirtualServerAction(c *cli.Context) error {
+	return rebuildServerAction(c, client.NewGPUVirtualClientV3)
+}
+
 // BaremetalCommands returns commands for baremetal GPU servers
 func BaremetalCommands() *cli.Command {
 	return &cli.Command{
@@ -130,6 +177,15 @@ func BaremetalCommands() *cli.Command {
 					},
 				}, flags.WaitCommandFlags...),
 				Action: deleteBaremetalServerAction,
+			},
+			{
+				Name:        "rebuild",
+				Usage:       "Rebuild server in a baremetal GPU cluster",
+				Description: "Trigger a rebuild of a specific server in a baremetal GPU cluster",
+				Category:    "servers",
+				ArgsUsage:   "<cluster_id> <server_id>",
+				Flags:       flags.WaitCommandFlags,
+				Action:      rebuildBaremetalServerAction,
 			},
 		},
 	}
@@ -174,6 +230,15 @@ func VirtualCommands() *cli.Command {
 					},
 				}, flags.WaitCommandFlags...),
 				Action: deleteVirtualServerAction,
+			},
+			{
+				Name:        "rebuild",
+				Usage:       "Rebuild server in a virtual GPU cluster",
+				Description: "Trigger a rebuild of a specific server in a virtual GPU cluster",
+				Category:    "servers",
+				ArgsUsage:   "<cluster_id> <server_id>",
+				Flags:       flags.WaitCommandFlags,
+				Action:      rebuildVirtualServerAction,
 			},
 		},
 	}

--- a/gcore/gpu/v3/clusters/requests.go
+++ b/gcore/gpu/v3/clusters/requests.go
@@ -392,6 +392,56 @@ func HardReboot(client *gcorecloud.ServiceClient, clusterID string) (r tasks.Res
 	return ApplyAction(client, clusterID, opts)
 }
 
+// UpdateServersSettingsOptsBuilder allows extensions to add parameters to update servers settings options.
+type UpdateServersSettingsOptsBuilder interface {
+	ToUpdateServersSettingsMap() (map[string]interface{}, error)
+}
+
+// UpdatedServerCredentials represents the credentials for patching server settings.
+type UpdatedServerCredentials struct {
+	SSHKeyName string `json:"ssh_key_name" validate:"required"`
+}
+
+// UpdatedServerSettings represents the server settings to patch.
+type UpdatedServerSettings struct {
+	Credentials *UpdatedServerCredentials `json:"credentials,omitempty"`
+	UserData    *string                 `json:"user_data,omitempty"`
+}
+
+// UpdateServersSettingsOpts specifies the parameters for the UpdateServersSettings method.
+type UpdateServersSettingsOpts struct {
+	ImageID         *string              `json:"image_id,omitempty" validate:"omitempty,uuid4"`
+	ServersSettings *UpdatedServerSettings `json:"servers_settings,omitempty"`
+}
+
+// Validate checks if the provided options are valid.
+func (opts UpdateServersSettingsOpts) Validate() error {
+	return gcorecloud.ValidateStruct(opts)
+}
+
+// ToUpdateServersSettingsMap builds a request body from UpdateServersSettingsOpts.
+func (opts UpdateServersSettingsOpts) ToUpdateServersSettingsMap() (map[string]interface{}, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
+	return gcorecloud.BuildRequestBody(opts, "")
+}
+
+// UpdateServersSettings updates the server settings for a GPU cluster.
+func UpdateServersSettings(client *gcorecloud.ServiceClient, clusterID string, opts UpdateServersSettingsOptsBuilder) (r GetResult) {
+	b, err := opts.ToUpdateServersSettingsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	url := ClusterServersSettingsURL(client, clusterID)
+	_, r.Err = client.Patch(url, b, &r.Body, &gcorecloud.RequestOpts{
+		OkCodes: []int{http.StatusOK},
+	})
+	return
+}
+
 func Start(client *gcorecloud.ServiceClient, clusterID string) (r tasks.Result) {
 	opts := ClusterActionsOpts{
 		Action: StartClusterAction,

--- a/gcore/gpu/v3/clusters/results.go
+++ b/gcore/gpu/v3/clusters/results.go
@@ -163,16 +163,19 @@ type ClusterServerSettings struct {
 }
 
 type Cluster struct {
-	ID              string                   `json:"id"`
-	Name            string                   `json:"name"`
-	Status          ClusterStatusType        `json:"status"`
-	Flavor          string                   `json:"flavor"`
-	Tags            []Tag                    `json:"tags"`
-	ServersCount    int                      `json:"servers_count"`
-	CreatedAt       gcorecloud.JSONRFC3339Z  `json:"created_at"`
-	UpdatedAt       *gcorecloud.JSONRFC3339Z `json:"updated_at"`
-	ServersIDs      *[]string                `json:"servers_ids"`
-	ServersSettings ClusterServerSettings    `json:"servers_settings"`
+	ID                string                   `json:"id"`
+	Name              string                   `json:"name"`
+	Status            ClusterStatusType        `json:"status"`
+	Flavor            string                   `json:"flavor"`
+	ImageID           string                   `json:"image_id"`
+	Tags              []Tag                    `json:"tags"`
+	ServersCount      int                      `json:"servers_count"`
+	CreatedAt         gcorecloud.JSONRFC3339Z  `json:"created_at"`
+	UpdatedAt         *gcorecloud.JSONRFC3339Z `json:"updated_at"`
+	HasPendingChanges bool                     `json:"has_pending_changes"`
+	ManagedBy         ManagedByOpt             `json:"managed_by"`
+	ServersIDs        *[]string                `json:"servers_ids"`
+	ServersSettings   ClusterServerSettings    `json:"servers_settings"`
 }
 
 // Tag represents a key-value pair used to tag resources like clusters, servers, volumes, etc.

--- a/gcore/gpu/v3/clusters/urls.go
+++ b/gcore/gpu/v3/clusters/urls.go
@@ -20,3 +20,8 @@ func ClusterURL(c *gcorecloud.ServiceClient, clusterID string) string {
 func ClusterActionURL(c *gcorecloud.ServiceClient, clusterID string) string {
 	return c.ServiceURL(clustersPath, clusterID, "action")
 }
+
+// ClusterServersSettingsURL returns URL for updating server settings of a specific GPU cluster
+func ClusterServersSettingsURL(c *gcorecloud.ServiceClient, clusterID string) string {
+	return c.ServiceURL(clustersPath, clusterID, "servers_settings")
+}

--- a/gcore/gpu/v3/servers/requests.go
+++ b/gcore/gpu/v3/servers/requests.go
@@ -1,6 +1,8 @@
 package servers
 
 import (
+	"net/http"
+
 	gcorecloud "github.com/G-Core/gcorelabscloud-go"
 	"github.com/G-Core/gcorelabscloud-go/gcore/task/v1/tasks"
 	"github.com/G-Core/gcorelabscloud-go/pagination"
@@ -13,8 +15,9 @@ type ListOptsBuilder interface {
 
 // ListOpts allows the filtering and sorting of paginated collections through the API.
 type ListOpts struct {
-	Limit  int `q:"limit" validate:"omitempty,gt=0"`
-	Offset int `q:"offset" validate:"omitempty,gte=0"`
+	Limit   int    `q:"limit" validate:"omitempty,gt=0"`
+	Offset  int    `q:"offset" validate:"omitempty,gte=0"`
+	OrderBy string `q:"order_by"`
 }
 
 // ToListClustersQuery formats a ListOpts into a query string.
@@ -103,5 +106,14 @@ func Delete(client *gcorecloud.ServiceClient, clusterID, serverID string, opts D
 		url += query
 	}
 	_, r.Err = client.DeleteWithResponse(url, &r.Body, nil) // nolint
+	return
+}
+
+// Rebuild triggers a rebuild of a specific server in a GPU cluster.
+func Rebuild(client *gcorecloud.ServiceClient, clusterID, serverID string) (r tasks.Result) {
+	url := ClusterServerRebuildURL(client, clusterID, serverID)
+	_, r.Err = client.Post(url, nil, &r.Body, &gcorecloud.RequestOpts{
+		OkCodes: []int{http.StatusOK},
+	})
 	return
 }

--- a/gcore/gpu/v3/servers/types.go
+++ b/gcore/gpu/v3/servers/types.go
@@ -8,18 +8,20 @@ import (
 
 // Server represents a server in a GPU cluster
 type Server struct {
-	ID             string                  `json:"id"`
-	ImageID        *string                 `json:"image_id"`
-	TaskID         *string                 `json:"task_id"`
-	Flavor         string                  `json:"flavor"`
-	KeypairID      *string                 `json:"keypair_id"`
-	Name           string                  `json:"name"`
-	Status         string                  `json:"status"`
-	IPAddresses    []string                `json:"ip_addresses"`
-	SecurityGroups []gcorecloud.ItemIDName `json:"security_groups"`
-	Tags           []Tag                   `json:"tags"`
-	CreatedAt      time.Time               `json:"created_at"`
-	UpdatedAt      time.Time               `json:"updated_at"`
+	ID                string                  `json:"id"`
+	ImageID           *string                 `json:"image_id"`
+	TaskID            *string                 `json:"task_id"`
+	Flavor            string                  `json:"flavor"`
+	KeypairID         *string                 `json:"keypair_id"`
+	SSHKeyName        *string                 `json:"ssh_key_name"`
+	Name              string                  `json:"name"`
+	Status            string                  `json:"status"`
+	IPAddresses       []string                `json:"ip_addresses"`
+	SecurityGroups    []gcorecloud.ItemIDName `json:"security_groups"`
+	Tags              []Tag                   `json:"tags"`
+	HasPendingChanges bool                    `json:"has_pending_changes"`
+	CreatedAt         time.Time               `json:"created_at"`
+	UpdatedAt         time.Time               `json:"updated_at"`
 }
 
 // Tag represents a server tag

--- a/gcore/gpu/v3/servers/urls.go
+++ b/gcore/gpu/v3/servers/urls.go
@@ -16,3 +16,8 @@ func ClusterServersURL(c *gcorecloud.ServiceClient, clusterID string) string {
 func ClusterServerURL(c *gcorecloud.ServiceClient, clusterID, serverID string) string {
 	return c.ServiceURL(clustersPath, clusterID, serversPath, serverID)
 }
+
+// ClusterServerRebuildURL returns URL for rebuilding a specific server in a GPU cluster
+func ClusterServerRebuildURL(c *gcorecloud.ServiceClient, clusterID, serverID string) string {
+	return c.ServiceURL(clustersPath, clusterID, serversPath, serverID, "rebuild")
+}


### PR DESCRIPTION
## Description

1. Added support for updating gpu cluster server settings.
2. Allowed rebuilding a single gpu cluster server with new settings. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have followed the style guidelines of this project
- [x] I have tested my changes with the latest version of Go

## Further comments
