### PR TITLE
GCLOUD2-26108 Migrate instance actions off v1 endpoints to v2 Action()

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Note: gcore-go does not provide a CLI.
 The legacy per-action instance endpoints (`POST /v1/instances/.../{start,stop,reboot,suspend,resume}`)
 are superseded by the unified v2 action endpoint (`POST /v2/instances/.../action`).
 
-- `instance/v1/instances.Start`, `.Stop`, `.Reboot`, `.Suspend`, `.Resume` are **deprecated**.
-  Use `instance/v2/instances.Action` with a v2 `ServiceClient` and the matching
-  `instance/v2/types.InstanceActionType` instead. The CLI `instance {start,stop,reboot,suspend,resume}`
+- `gcore/instance/v1/instances.Start`, `.Stop`, `.Reboot`, `.Suspend`, `.Resume` are **deprecated**.
+  Use `gcore/instance/v2/instances.Action` with a v2 `ServiceClient` and the matching
+  `gcore/instance/v2/types.InstanceActionType` instead. The CLI `instance {start,stop,reboot,suspend,resume}`
   commands and the Terraform provider already route through the v2 endpoint.
 - `PowerCycle` (`powercycle`) and `Resize` (`changeflavor`) have no v2 `Action` equivalent yet and are
   unchanged; migrating them requires adding the actions to the v2 enum on the cloud-api side first.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ Note: gcore-go does not provide a CLI.
 
 ---
 
+### Instance actions: v1 → v2 migration
+
+The legacy per-action instance endpoints (`POST /v1/instances/.../{start,stop,reboot,suspend,resume}`)
+are superseded by the unified v2 action endpoint (`POST /v2/instances/.../action`).
+
+- `instance/v1/instances.Start`, `.Stop`, `.Reboot`, `.Suspend`, `.Resume` are **deprecated**.
+  Use `instance/v2/instances.Action` with a v2 `ServiceClient` and the matching
+  `instance/v2/types.InstanceActionType` instead. The CLI `instance {start,stop,reboot,suspend,resume}`
+  commands and the Terraform provider already route through the v2 endpoint.
+- `PowerCycle` (`powercycle`) and `Resize` (`changeflavor`) have no v2 `Action` equivalent yet and are
+  unchanged; migrating them requires adding the actions to the v2 enum on the cloud-api side first.
+
+---
+
 Gcore cloud API client
 ====================================
 

--- a/client/instances/v1/instances/instances.go
+++ b/client/instances/v1/instances/instances.go
@@ -859,14 +859,22 @@ func runInstanceActionV2(c *cli.Context, helpName string, action typesV2.Instanc
 		_ = cli.ShowAppHelp(c)
 		return cli.NewExitError(err, 1)
 	}
-	clientV1, err := client.NewInstanceClientV1(c)
-	if err != nil {
-		_ = cli.ShowAppHelp(c)
-		return cli.NewExitError(err, 1)
-	}
 
 	results, err := instancesV2.Action(clientV2, instanceID, instancesV2.ActionOpts{Action: action}).Extract()
 	if err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	// Without --wait we only print the accepted task IDs, so skip building the
+	// v1 client (used solely for task polling and the instance lookup below).
+	if !c.Bool("wait") {
+		utils.ShowResults(results, c.String("format"))
+		return nil
+	}
+
+	clientV1, err := client.NewInstanceClientV1(c)
+	if err != nil {
+		_ = cli.ShowAppHelp(c)
 		return cli.NewExitError(err, 1)
 	}
 	return utils.WaitTaskAndShowResult(c, clientV1, results, true, func(task tasks.TaskID) (interface{}, error) {

--- a/client/instances/v1/instances/instances.go
+++ b/client/instances/v1/instances/instances.go
@@ -19,6 +19,8 @@ import (
 	"github.com/G-Core/gcorelabscloud-go/client/utils"
 	"github.com/G-Core/gcorelabscloud-go/gcore/instance/v1/instances"
 	"github.com/G-Core/gcorelabscloud-go/gcore/instance/v1/types"
+	instancesV2 "github.com/G-Core/gcorelabscloud-go/gcore/instance/v2/instances"
+	typesV2 "github.com/G-Core/gcorelabscloud-go/gcore/instance/v2/types"
 	"github.com/G-Core/gcorelabscloud-go/gcore/task/v1/tasks"
 	"github.com/G-Core/gcorelabscloud-go/gcore/volume/v1/volumes"
 )
@@ -841,29 +843,49 @@ var instanceDeleteCommand = cli.Command{
 	},
 }
 
+// runInstanceActionV2 routes an instance power action through the unified v2
+// POST /v2/instances/.../action endpoint (instancesV2.Action) instead of the
+// legacy per-action v1 endpoints. The action is asynchronous and returns a
+// task, so it waits (when --wait is set) and then shows the instance, matching
+// the create/resize commands and the Terraform provider's behavior.
+func runInstanceActionV2(c *cli.Context, helpName string, action typesV2.InstanceActionType) error {
+	instanceID, err := flags.GetFirstStringArg(c, instanceIDText)
+	if err != nil {
+		_ = cli.ShowCommandHelp(c, helpName)
+		return err
+	}
+	clientV2, err := client2.NewInstanceClientV2(c)
+	if err != nil {
+		_ = cli.ShowAppHelp(c)
+		return cli.NewExitError(err, 1)
+	}
+	clientV1, err := client.NewInstanceClientV1(c)
+	if err != nil {
+		_ = cli.ShowAppHelp(c)
+		return cli.NewExitError(err, 1)
+	}
+
+	results, err := instancesV2.Action(clientV2, instanceID, instancesV2.ActionOpts{Action: action}).Extract()
+	if err != nil {
+		return cli.NewExitError(err, 1)
+	}
+	return utils.WaitTaskAndShowResult(c, clientV1, results, true, func(task tasks.TaskID) (interface{}, error) {
+		instance, err := instances.Get(clientV1, instanceID).Extract()
+		if err != nil {
+			return nil, fmt.Errorf("cannot get instance with ID: %s. Error: %w", instanceID, err)
+		}
+		return instance, nil
+	})
+}
+
 var instanceStartCommand = cli.Command{
 	Name:      "start",
 	Usage:     "Start instance",
 	ArgsUsage: "<instance_id>",
 	Category:  "instance",
+	Flags:     flags.WaitCommandFlags,
 	Action: func(c *cli.Context) error {
-		instanceID, err := flags.GetFirstStringArg(c, instanceIDText)
-		if err != nil {
-			_ = cli.ShowCommandHelp(c, "start")
-			return err
-		}
-		client, err := client.NewInstanceClientV1(c)
-		if err != nil {
-			_ = cli.ShowAppHelp(c)
-			return cli.NewExitError(err, 1)
-		}
-
-		instance, err := instances.Start(client, instanceID).Extract()
-		if err != nil {
-			return cli.NewExitError(err, 1)
-		}
-		utils.ShowResults(instance, c.String("format"))
-		return nil
+		return runInstanceActionV2(c, "start", typesV2.InstanceActionTypeStart)
 	},
 }
 
@@ -872,24 +894,9 @@ var instanceStopCommand = cli.Command{
 	Usage:     "Stop instance",
 	ArgsUsage: "<instance_id>",
 	Category:  "instance",
+	Flags:     flags.WaitCommandFlags,
 	Action: func(c *cli.Context) error {
-		instanceID, err := flags.GetFirstStringArg(c, instanceIDText)
-		if err != nil {
-			_ = cli.ShowCommandHelp(c, "stop")
-			return err
-		}
-		client, err := client.NewInstanceClientV1(c)
-		if err != nil {
-			_ = cli.ShowAppHelp(c)
-			return cli.NewExitError(err, 1)
-		}
-
-		instance, err := instances.Stop(client, instanceID).Extract()
-		if err != nil {
-			return cli.NewExitError(err, 1)
-		}
-		utils.ShowResults(instance, c.String("format"))
-		return nil
+		return runInstanceActionV2(c, "stop", typesV2.InstanceActionTypeStop)
 	},
 }
 
@@ -924,24 +931,9 @@ var instanceRebootCommand = cli.Command{
 	Usage:     "Reboot instance",
 	ArgsUsage: "<instance_id>",
 	Category:  "instance",
+	Flags:     flags.WaitCommandFlags,
 	Action: func(c *cli.Context) error {
-		instanceID, err := flags.GetFirstStringArg(c, instanceIDText)
-		if err != nil {
-			_ = cli.ShowCommandHelp(c, "reboot")
-			return err
-		}
-		client, err := client.NewInstanceClientV1(c)
-		if err != nil {
-			_ = cli.ShowAppHelp(c)
-			return cli.NewExitError(err, 1)
-		}
-
-		instance, err := instances.Reboot(client, instanceID).Extract()
-		if err != nil {
-			return cli.NewExitError(err, 1)
-		}
-		utils.ShowResults(instance, c.String("format"))
-		return nil
+		return runInstanceActionV2(c, "reboot", typesV2.InstanceActionTypeReboot)
 	},
 }
 
@@ -950,24 +942,9 @@ var instanceSuspendCommand = cli.Command{
 	Usage:     "Suspend instance",
 	ArgsUsage: "<instance_id>",
 	Category:  "instance",
+	Flags:     flags.WaitCommandFlags,
 	Action: func(c *cli.Context) error {
-		instanceID, err := flags.GetFirstStringArg(c, instanceIDText)
-		if err != nil {
-			_ = cli.ShowCommandHelp(c, "suspend")
-			return err
-		}
-		client, err := client.NewInstanceClientV1(c)
-		if err != nil {
-			_ = cli.ShowAppHelp(c)
-			return cli.NewExitError(err, 1)
-		}
-
-		instance, err := instances.Suspend(client, instanceID).Extract()
-		if err != nil {
-			return cli.NewExitError(err, 1)
-		}
-		utils.ShowResults(instance, c.String("format"))
-		return nil
+		return runInstanceActionV2(c, "suspend", typesV2.InstanceActionTypeSuspend)
 	},
 }
 
@@ -976,24 +953,9 @@ var instanceResumeCommand = cli.Command{
 	Usage:     "Resume instance",
 	ArgsUsage: "<instance_id>",
 	Category:  "instance",
+	Flags:     flags.WaitCommandFlags,
 	Action: func(c *cli.Context) error {
-		instanceID, err := flags.GetFirstStringArg(c, instanceIDText)
-		if err != nil {
-			_ = cli.ShowCommandHelp(c, "resume")
-			return err
-		}
-		client, err := client.NewInstanceClientV1(c)
-		if err != nil {
-			_ = cli.ShowAppHelp(c)
-			return cli.NewExitError(err, 1)
-		}
-
-		instance, err := instances.Resume(client, instanceID).Extract()
-		if err != nil {
-			return cli.NewExitError(err, 1)
-		}
-		utils.ShowResults(instance, c.String("format"))
-		return nil
+		return runInstanceActionV2(c, "resume", typesV2.InstanceActionTypeResume)
 	},
 }
 

--- a/gcore/instance/v1/instances/requests.go
+++ b/gcore/instance/v1/instances/requests.go
@@ -484,12 +484,19 @@ func Delete(client *gcorecloud.ServiceClient, instanceID string, opts DeleteOpts
 }
 
 // Start instance.
+//
+// Deprecated: the unified v2 action endpoint supersedes the per-action v1
+// endpoints. Use instance/v2/instances.Action with a v2 ServiceClient and
+// types.InstanceActionTypeStart instead.
 func Start(client *gcorecloud.ServiceClient, id string) (r UpdateResult) {
 	_, r.Err = client.Post(startInstanceURL(client, id), nil, &r.Body, nil) // nolint
 	return
 }
 
 // Stop instance.
+//
+// Deprecated: use instance/v2/instances.Action with a v2 ServiceClient and
+// types.InstanceActionTypeStop instead.
 func Stop(client *gcorecloud.ServiceClient, id string) (r UpdateResult) {
 	_, r.Err = client.Post(stopInstanceURL(client, id), nil, &r.Body, nil) // nolint
 	return
@@ -502,18 +509,27 @@ func PowerCycle(client *gcorecloud.ServiceClient, id string) (r UpdateResult) {
 }
 
 // Reboot instance.
+//
+// Deprecated: use instance/v2/instances.Action with a v2 ServiceClient and
+// types.InstanceActionTypeReboot instead.
 func Reboot(client *gcorecloud.ServiceClient, id string) (r UpdateResult) {
 	_, r.Err = client.Post(rebootInstanceURL(client, id), nil, &r.Body, nil) // nolint
 	return
 }
 
 // Suspend instance.
+//
+// Deprecated: use instance/v2/instances.Action with a v2 ServiceClient and
+// types.InstanceActionTypeSuspend instead.
 func Suspend(client *gcorecloud.ServiceClient, id string) (r UpdateResult) {
 	_, r.Err = client.Post(suspendInstanceURL(client, id), nil, &r.Body, nil) // nolint
 	return
 }
 
 // Resume instance.
+//
+// Deprecated: use instance/v2/instances.Action with a v2 ServiceClient and
+// types.InstanceActionTypeResume instead.
 func Resume(client *gcorecloud.ServiceClient, id string) (r UpdateResult) {
 	_, r.Err = client.Post(resumeInstanceURL(client, id), nil, &r.Body, nil) // nolint
 	return

--- a/gcore/instance/v2/instances/testing/fixtures.go
+++ b/gcore/instance/v2/instances/testing/fixtures.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"github.com/G-Core/gcorelabscloud-go/gcore/task/v1/tasks"
 	"github.com/G-Core/gcorelabscloud-go/gcore/utils/metadata"
 )
 
@@ -12,11 +13,22 @@ const MetadataResponse = `
 }
 `
 
+const ActionResponse = `
+{
+  "tasks": [
+    "50f53a35-42ed-40c4-82b2-5a37fb3e00bc"
+  ]
+}
+`
+
 var (
 	instanceID = "ad1bb86e-2f83-4e0f-87c0-e1fd777d6352"
 	Metadata   = metadata.Metadata{
 		Key:      "db.name",
 		Value:    "pg",
 		ReadOnly: false,
+	}
+	ActionTasks = tasks.TaskResults{
+		Tasks: []tasks.TaskID{"50f53a35-42ed-40c4-82b2-5a37fb3e00bc"},
 	}
 )

--- a/gcore/instance/v2/instances/testing/requests_test.go
+++ b/gcore/instance/v2/instances/testing/requests_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	instancesV2 "github.com/G-Core/gcorelabscloud-go/gcore/instance/v2/instances"
+	"github.com/G-Core/gcorelabscloud-go/gcore/instance/v2/types"
 	th "github.com/G-Core/gcorelabscloud-go/testhelper"
 	fake "github.com/G-Core/gcorelabscloud-go/testhelper/client"
 	log "github.com/sirupsen/logrus"
@@ -14,6 +15,34 @@ import (
 
 func prepareMetadataItemTestURL(id string) string {
 	return fmt.Sprintf("/%s/instances/%d/%d/%s/%s", "v2", fake.ProjectID, fake.RegionID, id, "metadata_item")
+}
+
+func prepareActionTestURL(id string) string {
+	return fmt.Sprintf("/%s/instances/%d/%d/%s/%s", "v2", fake.ProjectID, fake.RegionID, id, "action")
+}
+
+func TestAction(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc(prepareActionTestURL(instanceID), func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `{"action": "start"}`)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := fmt.Fprint(w, ActionResponse)
+		if err != nil {
+			log.Error(err)
+		}
+	})
+
+	client := fake.ServiceTokenClient("instances", "v2")
+	opts := instancesV2.ActionOpts{Action: types.InstanceActionTypeStart}
+	actual, err := instancesV2.Action(client, instanceID, opts).Extract()
+	require.NoError(t, err)
+	require.Equal(t, &ActionTasks, actual)
 }
 
 func TestMetadataItemGet(t *testing.T) {


### PR DESCRIPTION
## Summary

Routes the legacy Go SDK's instance **power actions** off the per-action v1 endpoints and onto the unified v2 endpoint `POST /v2/instances/.../action` (`instance/v2/instances.Action`), so the cloud-api v1 action handlers can eventually be deprecated.

The endpoint version is determined by which `ServiceClient` is passed, so migration happens **at the call site** (build a v2 client and call `Action()`) — exactly how the Terraform provider and the CLI's own `create` command already work. The v1 wrapper functions are kept and marked deprecated rather than deleted, because WG still consumes this SDK.

## Changes

- **CLI** (`client/instances/v1/instances/instances.go`): `start` / `stop` / `reboot` / `suspend` / `resume` now call `instancesV2.Action(clientV2, …)` and wait on the returned task via `WaitTaskAndShowResult` (added `--wait` flags), through a shared `runInstanceActionV2` helper.
- **v1 SDK** (`gcore/instance/v1/instances/requests.go`): `Start` / `Stop` / `Reboot` / `Suspend` / `Resume` marked `// Deprecated:` pointing to v2 `Action()`. Signatures and behavior unchanged, so existing external callers keep working.
- **Tests**: new `TestAction` covering the v2 `Action()` request/response (previously uncovered).
- **README**: documents the v1 → v2 action migration and deprecation.

## Out of scope

- `PowerCycle` (`powercycle`) and `Resize` (`changeflavor`) stay on v1 — they have no v2 `Action` enum value yet and need a cloud-api change first (follow-up ticket).
- Removing the v1 action handlers from cloud-api itself.

## Verification

- `go build ./gcore/instance/... ./client/instances/...` — OK
- `go test ./gcore/instance/v1/instances/... ./gcore/instance/v2/instances/...` — pass (existing `TestStart…TestResume` still green; new `TestAction` green)
- `gofmt -l` / `go vet` clean on touched packages