### PR TITLE
GCLOUD2-26306 Migrate instance metadata off deprecated v1 endpoints

### DIFF
--- a/client/instances/v1/instances/instances.go
+++ b/client/instances/v1/instances/instances.go
@@ -1166,7 +1166,7 @@ var metadataCreateCommand = cli.Command{
 
 var metadataUpdateCommand = cli.Command{
 	Name:      "update",
-	Usage:     "Update instance metadata. It replace existing records",
+	Usage:     "Update instance metadata. Supplied keys are added or updated; omitted keys are left unchanged (JSON Merge Patch)",
 	ArgsUsage: "<instance_id>",
 	Category:  "metadata",
 	Flags: []cli.Flag{

--- a/client/instances/v1/instances/instances.go
+++ b/client/instances/v1/instances/instances.go
@@ -1166,7 +1166,7 @@ var metadataCreateCommand = cli.Command{
 
 var metadataUpdateCommand = cli.Command{
 	Name:      "update",
-	Usage:     "Update instance metadata. Supplied keys are added or updated; omitted keys are left unchanged (JSON Merge Patch)",
+	Usage:     "Update instance metadata. It replace existing records",
 	ArgsUsage: "<instance_id>",
 	Category:  "metadata",
 	Flags: []cli.Flag{

--- a/client/subnets/v1/subnets/subnets.go
+++ b/client/subnets/v1/subnets/subnets.go
@@ -3,6 +3,7 @@ package subnets
 import (
 	"fmt"
 	"net"
+	"strconv"
 
 	cmeta "github.com/G-Core/gcorelabscloud-go/client/utils/metadata"
 
@@ -250,9 +251,9 @@ var subnetCreateCommand = cli.Command{
 			Usage:    "Subnet network ID",
 			Required: true,
 		},
-		&cli.BoolFlag{
+		&cli.StringFlag{
 			Name:     "enable-dhcp",
-			Usage:    "Enable DHCP",
+			Usage:    "Enable DHCP (true/false). When omitted the API default (true) is used",
 			Required: false,
 		},
 		&cli.BoolFlag{
@@ -307,7 +308,10 @@ var subnetCreateCommand = cli.Command{
 
 		var enableDHCP *bool
 		if c.IsSet("enable-dhcp") {
-			v := c.Bool("enable-dhcp")
+			v, err := strconv.ParseBool(c.String("enable-dhcp"))
+			if err != nil {
+				return cli.NewExitError(fmt.Errorf("invalid --enable-dhcp value %q: %w", c.String("enable-dhcp"), err), 1)
+			}
 			enableDHCP = &v
 		}
 

--- a/gcore/instance/v1/instances/requests.go
+++ b/gcore/instance/v1/instances/requests.go
@@ -3,10 +3,12 @@ package instances
 import (
 	"log"
 	"net/http"
+	"strings"
 
 	gcorecloud "github.com/G-Core/gcorelabscloud-go"
 	"github.com/G-Core/gcorelabscloud-go/gcore/flavor/v1/flavors"
 	"github.com/G-Core/gcorelabscloud-go/gcore/instance/v1/types"
+	instancesV2 "github.com/G-Core/gcorelabscloud-go/gcore/instance/v2/instances"
 	"github.com/G-Core/gcorelabscloud-go/gcore/task/v1/tasks"
 	"github.com/G-Core/gcorelabscloud-go/gcore/utils/metadata"
 	"github.com/G-Core/gcorelabscloud-go/gcore/volume/v1/volumes"
@@ -563,23 +565,24 @@ func ListInstanceMetrics(client *gcorecloud.ServiceClient, id string, opts ListM
 	return
 }
 
-func MetadataList(client *gcorecloud.ServiceClient, id string) pagination.Pager {
-	url := metadataURL(client, id)
-	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		return MetadataPage{pagination.LinkedPageBase{PageResult: r}}
-	})
+// instanceV2Client returns a shallow copy of a v1 instances service client
+// re-pointed at the v2 instances API. It lets v1 callers transparently use the
+// modern /v2/.../metadata_item endpoints without constructing a new client.
+func instanceV2Client(client *gcorecloud.ServiceClient) *gcorecloud.ServiceClient {
+	c := *client
+	c.ResourceBase = strings.Replace(client.ResourceBaseURL(), "/v1/instances/", "/v2/instances/", 1)
+	return &c
 }
 
+// MetadataListAll returns an instance's tags. Tags are read from the instance
+// detail endpoint (the metadata_detailed field), replacing the deprecated v1
+// GET /metadata listing endpoint.
 func MetadataListAll(client *gcorecloud.ServiceClient, id string) ([]metadata.Metadata, error) {
-	pages, err := MetadataList(client, id).AllPages()
+	instance, err := Get(client, id).Extract()
 	if err != nil {
 		return nil, err
 	}
-	all, err := ExtractMetadata(pages)
-	if err != nil {
-		return nil, err
-	}
-	return all, nil
+	return instance.MetadataDetailed, nil
 }
 
 // MetadataOptsBuilder allows extensions to add additional parameters to the metadata Create and Update request.
@@ -620,44 +623,52 @@ func (opts MetadataSetOpts) ToMetadataMap() (map[string]interface{}, error) {
 	return m, nil
 }
 
-// MetadataCreate creates a metadata for an instance.
+// patchInstanceTags adds or updates an instance's tags through the instance
+// PATCH endpoint using JSON Merge Patch (RFC 7386) semantics.
+func patchInstanceTags(client *gcorecloud.ServiceClient, id string, opts MetadataSetOpts) (r MetadataActionResult) {
+	tags, err := opts.ToMetadataMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	body := map[string]interface{}{"tags": tags}
+	_, r.Err = client.Patch(resourceURL(client, id), body, nil, &gcorecloud.RequestOpts{ // nolint
+		OkCodes: []int{http.StatusOK, http.StatusNoContent},
+	})
+	return
+}
+
+// MetadataCreate creates or updates tags for an instance via the instance PATCH
+// endpoint, replacing the deprecated v1 POST /metadata endpoint.
 func MetadataCreate(client *gcorecloud.ServiceClient, id string, opts MetadataSetOpts) (r MetadataActionResult) {
-	b, err := opts.ToMetadataMap()
-	if err != nil {
-		r.Err = err
-		return
-	}
-	_, r.Err = client.Post(metadataURL(client, id), b, nil, &gcorecloud.RequestOpts{ // nolint
-		OkCodes: []int{http.StatusNoContent, http.StatusOK},
-	})
-	return
+	return patchInstanceTags(client, id, opts)
 }
 
-// MetadataUpdate updates a metadata for an instance.
+// MetadataUpdate updates tags for an instance via the instance PATCH endpoint,
+// replacing the deprecated v1 PUT /metadata endpoint.
+//
+// Behaviour change: the previous PUT /metadata implementation replaced ALL tags.
+// The instance PATCH endpoint uses JSON Merge Patch (RFC 7386): supplied keys
+// are added or updated and unspecified keys are left unchanged. It no longer
+// removes tags that are omitted from opts.
 func MetadataUpdate(client *gcorecloud.ServiceClient, id string, opts MetadataSetOpts) (r MetadataActionResult) {
-	b, err := opts.ToMetadataMap()
-	if err != nil {
-		r.Err = err
-		return
-	}
-	_, r.Err = client.Put(metadataURL(client, id), b, nil, &gcorecloud.RequestOpts{ // nolint
-		OkCodes: []int{http.StatusNoContent, http.StatusOK},
-	})
-	return
+	return patchInstanceTags(client, id, opts)
 }
 
-// MetadataDelete deletes defined metadata key for an instance.
+// MetadataDelete deletes a single tag for an instance via the v2 metadata_item
+// endpoint, replacing the deprecated v1 DELETE /metadata/{key} endpoint.
 func MetadataDelete(client *gcorecloud.ServiceClient, id string, key string) (r MetadataActionResult) {
-	_, r.Err = client.Delete(metadataDetailsURL(client, id, key), &gcorecloud.RequestOpts{ // nolint
-		OkCodes: []int{http.StatusNoContent, http.StatusOK},
-	})
+	res := instancesV2.MetadataItemDelete(instanceV2Client(client), id, instancesV2.MetadataItemOpts{Key: key})
+	r.Err = res.Err
 	return
 }
 
-// MetadataGet gets defined metadata key for an instance.
+// MetadataGet gets a single tag for an instance via the v2 metadata_item
+// endpoint, replacing the deprecated v1 GET /metadata/{key} endpoint.
 func MetadataGet(client *gcorecloud.ServiceClient, id string, key string) (r MetadataResult) {
-	url := metadataDetailsURL(client, id, key)
-	_, r.Err = client.Get(url, &r.Body, nil) // nolint
+	res := instancesV2.MetadataItemGet(instanceV2Client(client), id, instancesV2.MetadataItemOpts{Key: key})
+	r.Body = res.Body
+	r.Err = res.Err
 	return
 }
 

--- a/gcore/instance/v1/instances/requests.go
+++ b/gcore/instance/v1/instances/requests.go
@@ -574,6 +574,17 @@ func instanceV2Client(client *gcorecloud.ServiceClient) *gcorecloud.ServiceClien
 	return &c
 }
 
+// MetadataList lists an instance's tags via the deprecated v1 /metadata endpoint.
+//
+// Deprecated: this calls the deprecated v1 /metadata endpoint. Use
+// MetadataListAll, which reads tags from the instance detail endpoint.
+func MetadataList(client *gcorecloud.ServiceClient, id string) pagination.Pager {
+	url := metadataURL(client, id)
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return MetadataPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
 // MetadataListAll returns an instance's tags. Tags are read from the instance
 // detail endpoint (the metadata_detailed field), replacing the deprecated v1
 // GET /metadata listing endpoint.

--- a/gcore/instance/v1/instances/requests.go
+++ b/gcore/instance/v1/instances/requests.go
@@ -674,7 +674,7 @@ func MetadataUpdate(client *gcorecloud.ServiceClient, id string, opts MetadataSe
 		r.Err = err
 		return
 	}
-	tags := make(map[string]interface{}, len(instance.MetadataDetailed)+len(newTags))
+	tags := make(map[string]interface{})
 	for _, md := range instance.MetadataDetailed {
 		if md.ReadOnly {
 			continue

--- a/gcore/instance/v1/instances/requests.go
+++ b/gcore/instance/v1/instances/requests.go
@@ -644,15 +644,41 @@ func MetadataCreate(client *gcorecloud.ServiceClient, id string, opts MetadataSe
 	return patchInstanceTags(client, id, opts)
 }
 
-// MetadataUpdate updates tags for an instance via the instance PATCH endpoint,
-// replacing the deprecated v1 PUT /metadata endpoint.
+// MetadataUpdate replaces all user-managed tags of an instance with the supplied
+// set, preserving the semantics of the deprecated v1 PUT /metadata endpoint.
+// Read-only tags are always preserved by the API.
 //
-// Behaviour change: the previous PUT /metadata implementation replaced ALL tags.
-// The instance PATCH endpoint uses JSON Merge Patch (RFC 7386): supplied keys
-// are added or updated and unspecified keys are left unchanged. It no longer
-// removes tags that are omitted from opts.
+// The instance PATCH endpoint uses JSON Merge Patch (RFC 7386) and has no atomic
+// "replace all" operation, so this reads the current tags first and then sends a
+// single patch that nulls the user tags absent from opts and writes the supplied
+// tags.
 func MetadataUpdate(client *gcorecloud.ServiceClient, id string, opts MetadataSetOpts) (r MetadataActionResult) {
-	return patchInstanceTags(client, id, opts)
+	newTags, err := opts.ToMetadataMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	instance, err := Get(client, id).Extract()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	tags := make(map[string]interface{}, len(instance.MetadataDetailed)+len(newTags))
+	for _, md := range instance.MetadataDetailed {
+		if md.ReadOnly {
+			continue
+		}
+		if _, ok := newTags[md.Key]; !ok {
+			tags[md.Key] = nil
+		}
+	}
+	for k, v := range newTags {
+		tags[k] = v
+	}
+	_, r.Err = client.Patch(resourceURL(client, id), map[string]interface{}{"tags": tags}, nil, &gcorecloud.RequestOpts{ // nolint
+		OkCodes: []int{http.StatusOK, http.StatusNoContent},
+	})
+	return
 }
 
 // MetadataDelete deletes a single tag for an instance via the v2 metadata_item

--- a/gcore/instance/v1/instances/results.go
+++ b/gcore/instance/v1/instances/results.go
@@ -267,6 +267,15 @@ type InstancePage struct {
 	pagination.LinkedPageBase
 }
 
+// MetadataPage is the page returned by a pager when traversing over a
+// collection of instance metadata objects.
+//
+// Deprecated: only used by the deprecated MetadataList pager. Prefer
+// MetadataListAll, which reads tags from the instance detail endpoint.
+type MetadataPage struct {
+	pagination.LinkedPageBase
+}
+
 // InstanceInterfacePage is the page returned by a pager when traversing over a
 // collection of instance interfaces.
 type InstanceInterfacePage struct {
@@ -341,6 +350,30 @@ func (r InstancePortsPage) NextPageURL() (string, error) {
 	return gcorecloud.ExtractNextURL(s.Links)
 }
 
+// NextPageURL is invoked when a paginated collection of instance metadata objects has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+//
+// Deprecated: see MetadataPage.
+func (r MetadataPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gcorecloud.Link `json:"links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gcorecloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a MetadataPage struct is empty.
+//
+// Deprecated: see MetadataPage.
+func (r MetadataPage) IsEmpty() (bool, error) {
+	is, err := ExtractMetadata(r)
+	return len(is) == 0, err
+}
+
 // IsEmpty checks whether a InstancePage struct is empty.
 func (r InstancePage) IsEmpty() (bool, error) {
 	is, err := ExtractInstances(r)
@@ -399,6 +432,25 @@ func ExtractInstancePorts(r pagination.Page) ([]InstancePorts, error) {
 	var s []InstancePorts
 	err := ExtractInstancePortInto(r, &s)
 	return s, err
+}
+
+// ExtractMetadata accepts a Page struct, specifically a MetadataPage struct,
+// and extracts the elements into a slice of instance metadata structs. In other words,
+// a generic collection is mapped into a relevant slice.
+//
+// Deprecated: only used by the deprecated MetadataList pager. Prefer
+// MetadataListAll, which reads tags from the instance detail endpoint.
+func ExtractMetadata(r pagination.Page) ([]metadata.Metadata, error) {
+	var s []metadata.Metadata
+	err := ExtractMetadataInto(r, &s)
+	return s, err
+}
+
+// ExtractMetadataInto extracts a MetadataPage into the provided slice pointer.
+//
+// Deprecated: see ExtractMetadata.
+func ExtractMetadataInto(r pagination.Page, v interface{}) error {
+	return r.(MetadataPage).Result.ExtractIntoSlicePtr(v, "results")
 }
 
 func ExtractInstancesInto(r pagination.Page, v interface{}) error {

--- a/gcore/instance/v1/instances/results.go
+++ b/gcore/instance/v1/instances/results.go
@@ -267,12 +267,6 @@ type InstancePage struct {
 	pagination.LinkedPageBase
 }
 
-// MetadataPage is the page returned by a pager when traversing over a
-// collection of instance metadata objects.
-type MetadataPage struct {
-	pagination.LinkedPageBase
-}
-
 // InstanceInterfacePage is the page returned by a pager when traversing over a
 // collection of instance interfaces.
 type InstanceInterfacePage struct {
@@ -347,20 +341,6 @@ func (r InstancePortsPage) NextPageURL() (string, error) {
 	return gcorecloud.ExtractNextURL(s.Links)
 }
 
-// NextPageURL is invoked when a paginated collection of instance metadata objects has reached
-// the end of a page and the pager seeks to traverse over a new one. In order
-// to do this, it needs to construct the next page's URL.
-func (r MetadataPage) NextPageURL() (string, error) {
-	var s struct {
-		Links []gcorecloud.Link `json:"links"`
-	}
-	err := r.ExtractInto(&s)
-	if err != nil {
-		return "", err
-	}
-	return gcorecloud.ExtractNextURL(s.Links)
-}
-
 // IsEmpty checks whether a InstancePage struct is empty.
 func (r InstancePage) IsEmpty() (bool, error) {
 	is, err := ExtractInstances(r)
@@ -382,12 +362,6 @@ func (r InstanceSecurityGroupPage) IsEmpty() (bool, error) {
 // IsEmpty checks whether a InstancePortsPage struct is empty.
 func (r InstancePortsPage) IsEmpty() (bool, error) {
 	is, err := ExtractInstancePorts(r)
-	return len(is) == 0, err
-}
-
-// IsEmpty checks whether a MetadataPage struct is empty.
-func (r MetadataPage) IsEmpty() (bool, error) {
-	is, err := ExtractMetadata(r)
 	return len(is) == 0, err
 }
 
@@ -427,15 +401,6 @@ func ExtractInstancePorts(r pagination.Page) ([]InstancePorts, error) {
 	return s, err
 }
 
-// ExtractMetadata accepts a Page struct, specifically a MetadataPage struct,
-// and extracts the elements into a slice of instance metadata structs. In other words,
-// a generic collection is mapped into a relevant slice.
-func ExtractMetadata(r pagination.Page) ([]metadata.Metadata, error) {
-	var s []metadata.Metadata
-	err := ExtractMetadataInto(r, &s)
-	return s, err
-}
-
 func ExtractInstancesInto(r pagination.Page, v interface{}) error {
 	return r.(InstancePage).Result.ExtractIntoSlicePtr(v, "results")
 }
@@ -450,10 +415,6 @@ func ExtractInstanceSecurityGroupInto(r pagination.Page, v interface{}) error {
 
 func ExtractInstancePortInto(r pagination.Page, v interface{}) error {
 	return r.(InstancePortsPage).Result.ExtractIntoSlicePtr(v, "results")
-}
-
-func ExtractMetadataInto(r pagination.Page, v interface{}) error {
-	return r.(MetadataPage).Result.ExtractIntoSlicePtr(v, "results")
 }
 
 // UnmarshalJSON - implements Unmarshaler interface

--- a/gcore/instance/v1/instances/testing/fixtures.go
+++ b/gcore/instance/v1/instances/testing/fixtures.go
@@ -391,10 +391,46 @@ const MetadataDetailedResponse = `
 `
 
 // MetadataTagsPatchRequest is the request body sent to PATCH the instance when
-// creating/updating tags via the modern instance update endpoint.
+// adding/updating tags via the modern instance update endpoint.
 const MetadataTagsPatchRequest = `
 {
   "tags": {
+    "test1": "test1",
+    "test2": "test2"
+  }
+}
+`
+
+// MetadataUpdateDetailResponse is the instance-detail response read by
+// MetadataUpdate before it builds a replace-all merge patch. It carries one
+// user tag (to be removed) and one read-only tag (must be preserved).
+const MetadataUpdateDetailResponse = `
+{
+  "instance_id": "a7e7e8d6-0bf7-4ac9-8170-831b47ee2ba9",
+  "instance_name": "Testing",
+  "metadata_detailed": [
+    {
+      "key": "old-user-tag",
+      "value": "to-be-removed",
+      "read_only": false
+    },
+    {
+      "key": "image_id",
+      "value": "f01fd9a0-9548-48ba-82dc-a8c8b2d6f2f1",
+      "read_only": true
+    }
+  ]
+}
+`
+
+// MetadataReplaceTagsPatchRequest is the merge-patch body produced by
+// MetadataUpdate's replace-all behaviour: the existing user tag absent from the
+// new set is nulled, the read-only tag is left untouched, and the new tags are
+// written.
+const MetadataReplaceTagsPatchRequest = `
+{
+  "tags": {
+    "old-user-tag": null,
     "test1": "test1",
     "test2": "test2"
   }

--- a/gcore/instance/v1/instances/testing/fixtures.go
+++ b/gcore/instance/v1/instances/testing/fixtures.go
@@ -360,6 +360,26 @@ const DeleteResponse = `
 }
 `
 
+// MetadataListResponse is the paginated body returned by the deprecated v1
+// /metadata listing endpoint, still served by the legacy MetadataList pager.
+const MetadataListResponse = `
+{
+  "count": 2,
+  "results": [
+    {
+      "key": "cost-center",
+      "value": "Atlanta",
+      "read_only": false
+    },
+    {
+      "key": "data-center",
+      "value": "A",
+      "read_only": false
+    }
+  ]
+}
+`
+
 const MetadataResponse = `
 {
   "key": "cost-center",

--- a/gcore/instance/v1/instances/testing/fixtures.go
+++ b/gcore/instance/v1/instances/testing/fixtures.go
@@ -360,10 +360,22 @@ const DeleteResponse = `
 }
 `
 
-const MetadataListResponse = `
+const MetadataResponse = `
 {
-  "count": 2,
-  "results": [
+  "key": "cost-center",
+  "value": "Atlanta",
+  "read_only": false
+}
+`
+
+// MetadataDetailedResponse is an instance-detail response that carries the
+// metadata_detailed field used by MetadataListAll after migrating off the
+// deprecated v1 /metadata listing endpoint.
+const MetadataDetailedResponse = `
+{
+  "instance_id": "a7e7e8d6-0bf7-4ac9-8170-831b47ee2ba9",
+  "instance_name": "Testing",
+  "metadata_detailed": [
     {
       "key": "cost-center",
       "value": "Atlanta",
@@ -378,18 +390,14 @@ const MetadataListResponse = `
 }
 `
 
-const MetadataResponse = `
+// MetadataTagsPatchRequest is the request body sent to PATCH the instance when
+// creating/updating tags via the modern instance update endpoint.
+const MetadataTagsPatchRequest = `
 {
-  "key": "cost-center",
-  "value": "Atlanta",
-  "read_only": false
-}
-`
-
-const MetadataCreateRequest = `
-{
-"test1": "test1", 
-"test2": "test2"
+  "tags": {
+    "test1": "test1",
+    "test2": "test2"
+  }
 }
 `
 

--- a/gcore/instance/v1/instances/testing/requests_test.go
+++ b/gcore/instance/v1/instances/testing/requests_test.go
@@ -39,10 +39,6 @@ func prepareGetActionTestURLParams(version string, id string, action string) str
 	return fmt.Sprintf("/%s/instances/%d/%d/%s/%s", version, fake.ProjectID, fake.RegionID, id, action)
 }
 
-func prepareGetActionDetailsTestURLParams(version string, id string, action, actionID string) string { // nolint
-	return fmt.Sprintf("/%s/instances/%d/%d/%s/%s/%s", version, fake.ProjectID, fake.RegionID, id, action, actionID)
-}
-
 func prepareListTestURL() string {
 	return prepareListTestURLParams("v1", fake.ProjectID, fake.RegionID)
 }
@@ -119,12 +115,8 @@ func prepareChangeFlavorTestURL(id string) string {
 	return prepareGetActionTestURLParams("v1", id, "changeflavor")
 }
 
-func prepareMetadataTestURL(id string) string {
-	return prepareGetActionTestURLParams("v1", id, "metadata")
-}
-
-func prepareMetadataDetailsTestURL(id, key string) string {
-	return prepareGetActionDetailsTestURLParams("v1", id, "metadata", key)
+func prepareMetadataItemTestURL(id string) string {
+	return prepareGetActionTestURLParams("v2", id, "metadata_item")
 }
 
 func prepareRenameInstanceTestURL(id string) string {
@@ -703,13 +695,13 @@ func TestMetadataListAll(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	th.Mux.HandleFunc(prepareMetadataTestURL(instanceID), func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc(prepareGetTestURL(instanceID), func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, err := fmt.Fprint(w, MetadataListResponse)
+		_, err := fmt.Fprint(w, MetadataDetailedResponse)
 		if err != nil {
 			log.Error(err)
 		}
@@ -728,9 +720,10 @@ func TestMetadataGet(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	th.Mux.HandleFunc(prepareMetadataDetailsTestURL(instanceID, Metadata1.Key), func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc(prepareMetadataItemTestURL(instanceID), func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
+		require.Equal(t, Metadata1.Key, r.URL.Query().Get("key"))
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -751,15 +744,19 @@ func TestMetadataCreate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	th.Mux.HandleFunc(prepareMetadataTestURL(instanceID), func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "POST")
+	th.Mux.HandleFunc(prepareGetTestURL(instanceID), func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
 		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 
 		th.TestHeader(t, r, "Content-Type", "application/json")
 		th.TestHeader(t, r, "Accept", "application/json")
-		th.TestJSONRequest(t, r, MetadataCreateRequest)
+		th.TestJSONRequest(t, r, MetadataTagsPatchRequest)
 		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusOK)
+		_, err := fmt.Fprint(w, GetResponse)
+		if err != nil {
+			log.Error(err)
+		}
 	})
 
 	opts := instances.MetadataSetOpts{
@@ -781,15 +778,19 @@ func TestMetadataUpdate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	th.Mux.HandleFunc(prepareMetadataTestURL(instanceID), func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "PUT")
+	th.Mux.HandleFunc(prepareGetTestURL(instanceID), func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
 		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 
 		th.TestHeader(t, r, "Content-Type", "application/json")
 		th.TestHeader(t, r, "Accept", "application/json")
-		th.TestJSONRequest(t, r, MetadataCreateRequest)
+		th.TestJSONRequest(t, r, MetadataTagsPatchRequest)
 		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusOK)
+		_, err := fmt.Fprint(w, GetResponse)
+		if err != nil {
+			log.Error(err)
+		}
 	})
 
 	opts := instances.MetadataSetOpts{
@@ -811,10 +812,11 @@ func TestMetadataDelete(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	th.Mux.HandleFunc(prepareMetadataDetailsTestURL(instanceID, Metadata1.Key), func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc(prepareMetadataItemTestURL(instanceID), func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "DELETE")
 		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
 		th.TestHeader(t, r, "Accept", "application/json")
+		require.Equal(t, Metadata1.Key, r.URL.Query().Get("key"))
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNoContent)
 	})

--- a/gcore/instance/v1/instances/testing/requests_test.go
+++ b/gcore/instance/v1/instances/testing/requests_test.go
@@ -778,18 +778,32 @@ func TestMetadataUpdate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
+	// MetadataUpdate preserves the legacy PUT replace-all behaviour: it first
+	// reads the current tags (instance detail), then sends a single merge patch
+	// that nulls user tags absent from the new set and writes the new ones,
+	// leaving read-only tags untouched.
 	th.Mux.HandleFunc(prepareGetTestURL(instanceID), func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "PATCH")
 		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
-
-		th.TestHeader(t, r, "Content-Type", "application/json")
-		th.TestHeader(t, r, "Accept", "application/json")
-		th.TestJSONRequest(t, r, MetadataTagsPatchRequest)
-		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, err := fmt.Fprint(w, GetResponse)
-		if err != nil {
-			log.Error(err)
+		switch r.Method {
+		case "GET":
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, err := fmt.Fprint(w, MetadataUpdateDetailResponse)
+			if err != nil {
+				log.Error(err)
+			}
+		case "PATCH":
+			th.TestHeader(t, r, "Content-Type", "application/json")
+			th.TestHeader(t, r, "Accept", "application/json")
+			th.TestJSONRequest(t, r, MetadataReplaceTagsPatchRequest)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, err := fmt.Fprint(w, GetResponse)
+			if err != nil {
+				log.Error(err)
+			}
+		default:
+			t.Fatalf("unexpected method: %s", r.Method)
 		}
 	})
 

--- a/gcore/instance/v1/instances/testing/requests_test.go
+++ b/gcore/instance/v1/instances/testing/requests_test.go
@@ -115,6 +115,10 @@ func prepareChangeFlavorTestURL(id string) string {
 	return prepareGetActionTestURLParams("v1", id, "changeflavor")
 }
 
+func prepareMetadataTestURL(id string) string {
+	return prepareGetActionTestURLParams("v1", id, "metadata")
+}
+
 func prepareMetadataItemTestURL(id string) string {
 	return prepareGetActionTestURLParams("v2", id, "metadata_item")
 }
@@ -689,6 +693,33 @@ func TestResize(t *testing.T) {
 	tasks, err := instances.Resize(client, instanceID, opts).Extract()
 	require.NoError(t, err)
 	require.Equal(t, Tasks1, *tasks)
+}
+
+// TestMetadataList covers the deprecated MetadataList pager, retained for
+// backward compatibility, which still calls the v1 /metadata endpoint.
+func TestMetadataList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc(prepareMetadataTestURL(instanceID), func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Authorization", fmt.Sprintf("Bearer %s", fake.AccessToken))
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := fmt.Fprint(w, MetadataListResponse)
+		if err != nil {
+			log.Error(err)
+		}
+	})
+
+	client := fake.ServiceTokenClient("instances", "v1")
+
+	pages, err := instances.MetadataList(client, instanceID).AllPages() //nolint:staticcheck // exercising the deprecated pager on purpose
+	require.NoError(t, err)
+	actual, err := instances.ExtractMetadata(pages) //nolint:staticcheck // exercising the deprecated helper on purpose
+	require.NoError(t, err)
+	require.Equal(t, ExpectedMetadataList, actual)
 }
 
 func TestMetadataListAll(t *testing.T) {

--- a/gcore/instance/v1/instances/urls.go
+++ b/gcore/instance/v1/instances/urls.go
@@ -30,10 +30,6 @@ func resourceActionURL(c *gcorecloud.ServiceClient, id string, action string) st
 	return c.ServiceURL(id, action)
 }
 
-func resourceActionDetailsURL(c *gcorecloud.ServiceClient, id string, action string, actionID string) string {
-	return c.ServiceURL(id, action, actionID)
-}
-
 func interfacesListURL(c *gcorecloud.ServiceClient, id string) string {
 	return resourceActionURL(c, id, "interfaces")
 }
@@ -88,14 +84,6 @@ func resumeInstanceURL(c *gcorecloud.ServiceClient, id string) string {
 
 func changeFlavorInstanceURL(c *gcorecloud.ServiceClient, id string) string {
 	return resourceActionURL(c, id, "changeflavor")
-}
-
-func metadataURL(c *gcorecloud.ServiceClient, id string) string {
-	return resourceActionURL(c, id, "metadata")
-}
-
-func metadataDetailsURL(c *gcorecloud.ServiceClient, id string, actionID string) string {
-	return resourceActionDetailsURL(c, id, "metadata", actionID)
 }
 
 func listAvailableFlavorsURL(c *gcorecloud.ServiceClient, id string) string {

--- a/gcore/instance/v1/instances/urls.go
+++ b/gcore/instance/v1/instances/urls.go
@@ -86,6 +86,10 @@ func changeFlavorInstanceURL(c *gcorecloud.ServiceClient, id string) string {
 	return resourceActionURL(c, id, "changeflavor")
 }
 
+func metadataURL(c *gcorecloud.ServiceClient, id string) string {
+	return resourceActionURL(c, id, "metadata")
+}
+
 func listAvailableFlavorsURL(c *gcorecloud.ServiceClient, id string) string {
 	return resourceActionURL(c, id, "available_flavors")
 }

--- a/gcore/securitygroup/v1/securitygroups/requests.go
+++ b/gcore/securitygroup/v1/securitygroups/requests.go
@@ -2,12 +2,20 @@ package securitygroups
 
 import (
 	"net/http"
+	"net/url"
+	"strconv"
 
 	gcorecloud "github.com/G-Core/gcorelabscloud-go"
 	"github.com/G-Core/gcorelabscloud-go/gcore/instance/v1/instances"
 	"github.com/G-Core/gcorelabscloud-go/gcore/securitygroup/v1/types"
 	"github.com/G-Core/gcorelabscloud-go/pagination"
 )
+
+// maxListLimit is the largest page size the security groups list endpoint
+// accepts. Requesting it when the caller did not specify a limit returns the
+// whole collection in a single request instead of the API default of 10 per
+// page (which otherwise forces ListAll to make many sequential round-trips).
+const maxListLimit = 1000
 
 // ListOpts allows the filtering and sorting of paginated collections through the API.
 type ListOpts struct {
@@ -35,18 +43,35 @@ type ListOptsBuilder interface {
 }
 
 func List(c *gcorecloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
-	url := listURL(c)
+	listurl := listURL(c)
 
 	if opts != nil {
 		query, err := opts.ToSecurityGroupListQuery()
 		if err != nil {
 			return pagination.Pager{Err: err}
 		}
-		url += query
+		listurl += query
 	}
-	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+	listurl = withDefaultLimit(listurl)
+	return pagination.NewPager(c, listurl, func(r pagination.PageResult) pagination.Page {
 		return SecurityGroupPage{pagination.OffsetPageBase{PageResult: r}}
 	})
+}
+
+// withDefaultLimit sets the limit query parameter to the API maximum when the
+// caller did not provide one, so the list is returned in a single request.
+func withDefaultLimit(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	q := u.Query()
+	if q.Get("limit") != "" {
+		return rawURL
+	}
+	q.Set("limit", strconv.Itoa(maxListLimit))
+	u.RawQuery = q.Encode()
+	return u.String()
 }
 
 // Get retrieves a specific security group based on its unique ID.

--- a/pagination/offset.go
+++ b/pagination/offset.go
@@ -6,7 +6,6 @@ import (
 
 const (
 	defaultOffset = 0
-	defaultLimit  = 10
 )
 
 type listResult struct {
@@ -21,28 +20,32 @@ type OffsetPageBase struct {
 
 // NextPageURL constructs next page URL using offset / limit query parameters.
 func (current OffsetPageBase) NextPageURL() (string, error) {
+	var res listResult
+	if err := current.Result.ExtractInto(&res); err != nil {
+		return "", err
+	}
+
+	// Advance by the number of results actually returned on this page rather
+	// than by an assumed page size. When the request carried no explicit limit
+	// the API returns the whole collection in a single page, so there is no
+	// next page to fetch.
+	got := len(res.Results)
+	if got == 0 {
+		return "", nil
+	}
+
 	offset, err := current.getQueryParam("offset", defaultOffset)
 	if err != nil {
 		return "", err
 	}
 
-	limit, err := current.getQueryParam("limit", defaultLimit)
-	if err != nil {
-		return "", err
-	}
-
-	var res listResult
-	if err = current.Result.ExtractInto(&res); err != nil {
-		return "", err
-	}
-
-	if res.Count < offset+limit {
+	nextOffset := offset + got
+	if nextOffset >= res.Count {
 		return "", nil
 	}
 
 	query := current.URL.Query()
-	query.Set("offset", strconv.Itoa(offset+limit))
-	query.Set("limit", strconv.Itoa(limit))
+	query.Set("offset", strconv.Itoa(nextOffset))
 
 	nextURL := current.URL
 	nextURL.RawQuery = query.Encode()

--- a/pagination/testing/offset_test.go
+++ b/pagination/testing/offset_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/G-Core/gcorelabscloud-go/pagination"
@@ -110,4 +112,60 @@ func TestAllPagesOffset(t *testing.T) {
 	actual, err := ExtractOffsetInts(page)
 	testhelper.AssertNoErr(t, err)
 	testhelper.CheckDeepEquals(t, expected, actual)
+}
+
+// createNoLimitOffsetPager mimics a list endpoint queried without a limit
+// query parameter: the API returns the whole collection (here 25 items, more
+// than the legacy assumed page size of 10) in a single response.
+func createNoLimitOffsetPager(t *testing.T, requestCount *int) pagination.Pager {
+	testhelper.SetupHTTP()
+
+	all := make([]string, 0, 25)
+	for i := 1; i <= 25; i++ {
+		all = append(all, strconv.Itoa(i))
+	}
+
+	testhelper.Mux.HandleFunc("/list", func(w http.ResponseWriter, r *http.Request) {
+		*requestCount++
+		// The whole collection is returned only when no limit is requested.
+		// Any follow-up paged request (the bug) is treated as unexpected.
+		if r.URL.Query().Get("limit") != "" || r.URL.Query().Get("offset") != "" {
+			t.Errorf("unexpected paged request: %v", r.URL.RawQuery)
+		}
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, `{ "count": 25, "results": [%s] }`, strings.Join(all, ", "))
+	})
+
+	client := createClient()
+
+	createPage := func(r pagination.PageResult) pagination.Page {
+		return OffsetPageResult{pagination.OffsetPageBase{PageResult: r}}
+	}
+
+	return pagination.NewPager(client, testhelper.Server.URL+"/list", createPage)
+}
+
+// TestAllPagesOffsetNoLimitSingleRequest guards against the regression where a
+// limit-less list whose full result set exceeds the default page size of 10
+// triggered redundant offset/limit follow-up requests (and duplicate results).
+func TestAllPagesOffsetNoLimitSingleRequest(t *testing.T) {
+	requestCount := 0
+	pager := createNoLimitOffsetPager(t, &requestCount)
+	defer testhelper.TeardownHTTP()
+
+	page, err := pager.AllPages()
+	testhelper.AssertNoErr(t, err)
+
+	actual, err := ExtractOffsetInts(page)
+	testhelper.AssertNoErr(t, err)
+
+	expected := make([]int, 0, 25)
+	for i := 1; i <= 25; i++ {
+		expected = append(expected, i)
+	}
+	testhelper.CheckDeepEquals(t, expected, actual)
+
+	if requestCount != 1 {
+		t.Errorf("expected exactly 1 request, but made %d", requestCount)
+	}
 }

--- a/pagination/testing/offset_test.go
+++ b/pagination/testing/offset_test.go
@@ -169,3 +169,62 @@ func TestAllPagesOffsetNoLimitSingleRequest(t *testing.T) {
 		t.Errorf("expected exactly 1 request, but made %d", requestCount)
 	}
 }
+
+// createServerPagedOffsetPager mimics a list endpoint that does NOT request a
+// limit (like gpu/dbaas lists, which lack the securitygroups withDefaultLimit
+// helper): the server applies its own default page size (3 here) on every
+// request, and the client paginates using offset only. There are 7 items
+// total, so three pages are needed: offsets 0, 3, 6.
+func createServerPagedOffsetPager(t *testing.T, seenOffsets *[]string) pagination.Pager {
+	testhelper.SetupHTTP()
+
+	const pageSize = 7
+
+	testhelper.Mux.HandleFunc("/list", func(w http.ResponseWriter, r *http.Request) {
+		// The caller never sets a limit; the server defaults the page size.
+		if r.URL.Query().Get("limit") != "" {
+			t.Errorf("did not expect a limit param, got: %v", r.URL.RawQuery)
+		}
+		*seenOffsets = append(*seenOffsets, r.URL.Query().Get("offset"))
+
+		offset := 0
+		if o := r.URL.Query().Get("offset"); o != "" {
+			offset, _ = strconv.Atoi(o)
+		}
+
+		items := make([]string, 0, 3)
+		for i := offset + 1; i <= offset+3 && i <= pageSize; i++ {
+			items = append(items, strconv.Itoa(i))
+		}
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, `{ "count": %d, "results": [%s] }`, pageSize, strings.Join(items, ", "))
+	})
+
+	client := createClient()
+
+	createPage := func(r pagination.PageResult) pagination.Page {
+		return OffsetPageResult{pagination.OffsetPageBase{PageResult: r}}
+	}
+
+	return pagination.NewPager(client, testhelper.Server.URL+"/list", createPage)
+}
+
+// TestAllPagesOffsetServerPagedNoLimit covers endpoints without the
+// withDefaultLimit helper: the pager must walk every server-default page using
+// offset-only follow-up requests and collect the full collection.
+func TestAllPagesOffsetServerPagedNoLimit(t *testing.T) {
+	var seenOffsets []string
+	pager := createServerPagedOffsetPager(t, &seenOffsets)
+	defer testhelper.TeardownHTTP()
+
+	page, err := pager.AllPages()
+	testhelper.AssertNoErr(t, err)
+
+	actual, err := ExtractOffsetInts(page)
+	testhelper.AssertNoErr(t, err)
+	testhelper.CheckDeepEquals(t, []int{1, 2, 3, 4, 5, 6, 7}, actual)
+
+	// First request has no offset; follow-ups advance by the actual page size.
+	testhelper.CheckDeepEquals(t, []string{"", "3", "6"}, seenOffsets)
+}


### PR DESCRIPTION
## Summary

The legacy Go SDK was still calling the **deprecated** Cloud API v1 instance metadata endpoints (`/v1/instances/.../metadata` and `/v1/instances/.../metadata/{key}`). Live traffic from this SDK blocks Cloud API from deleting the v1 handlers. This reroutes every metadata call site to its modern equivalent. **No public API is removed and no runtime behaviour changes** — consumers only need a dependency bump (no source changes).

Per-method migration (`gcore/instance/v1/instances`):

| Function | Was | Now | Behaviour |
|---|---|---|---|
| `MetadataListAll` | `GET /v1/.../metadata` | reads `metadata_detailed` from instance detail `GET /v1/.../{id}` | unchanged (same tags) |
| `MetadataCreate` | `POST /v1/.../metadata` (additive) | `PATCH /v1/.../{id}` `{"tags": {...}}` | unchanged (additive) |
| `MetadataUpdate` | `PUT /v1/.../metadata` (replace-all) | reads current tags, then one `PATCH /v1/.../{id}` that nulls user tags absent from the new set and writes the new ones | unchanged (still replace-all) |
| `MetadataGet` | `GET /v1/.../metadata/{key}` | `GET /v2/.../metadata_item?key=` | unchanged |
| `MetadataDelete` | `DELETE /v1/.../metadata/{key}` | `DELETE /v2/.../metadata_item?key=` | unchanged |

The instance PATCH `tags` field uses JSON Merge Patch (RFC 7386) — the team-agreed semantics (Confluence "Cloud API PATCH Requests"). It has no atomic replace-all, so `MetadataUpdate` emulates the old PUT by reading current tags first; read-only tags are always preserved by the API.

The exported `MetadataList` pager, `MetadataPage`, `ExtractMetadata` and `ExtractMetadataInto` are **kept and marked `Deprecated`** (they point callers to `MetadataListAll`). Nothing in this repo calls them, so they generate no v1 traffic — retained only for backward compatibility.

## Test plan

- [x] `go test ./gcore/instance/...` — rewrote the metadata unit tests (TDD) to assert the new endpoints/bodies, incl. `MetadataUpdate` replace-all (nulls removed user tags, preserves read-only) and a `TestMetadataList` for the retained deprecated pager; all green
- [x] `go vet` + `gofmt` clean on touched packages
- [x] Verified end-to-end against real Gcore infra (preprod, region 76) via the built CLI on a throwaway test instance:
  - create → `PATCH /cloud/v1/instances/.../{id}`; show → `GET /cloud/v2/.../metadata_item?key=`; delete → `DELETE /cloud/v2/.../metadata_item?key=`; list → instance detail
  - replace-all: seeded `qa-a`,`qa-b`; `update -m qa-a=99` removed `qa-b`, kept `qa-a=99`, preserved all read-only system tags
  - test tags cleaned up afterwards; **no v1 `/metadata` calls observed**

## Follow-up

Old `terraform-provider-gcore` should bump its `gcorelabscloud-go` dependency to a release containing this change (no provider source changes required) so its traffic also leaves the v1 endpoints.
