### PR TITLE
feat(gpu): per-interface security_groups, deprecate top-level

### DIFF
--- a/gcore/ai/v1/ais/requests.go
+++ b/gcore/ai/v1/ais/requests.go
@@ -47,18 +47,21 @@ type CreateOptsBuilder interface {
 
 // CreateOpts represents options used to create a AI Cluster.
 type CreateOpts struct {
-	Flavor         string                                  `json:"flavor" validate:"required,min=1"`
-	Name           string                                  `json:"name" validate:"required,min=3,max=63"`
-	ImageID        string                                  `json:"image_id" validate:"required,uuid4"`
-	Interfaces     []instances.InterfaceInstanceCreateOpts `json:"interfaces" validate:"required,dive"`
-	Volumes        []instances.CreateVolumeOpts            `json:"volumes,omitempty" validate:"omitempty,required,dive"`
-	SecurityGroups []gcorecloud.ItemID                     `json:"security_groups,omitempty" validate:"omitempty,dive,uuid4"`
-	Keypair        string                                  `json:"keypair_name,omitempty"`
-	Password       string                                  `json:"password" validate:"omitempty,required_with=Username"`
-	Username       string                                  `json:"username" validate:"omitempty,required_with=Password"`
-	UserData       string                                  `json:"user_data,omitempty" validate:"omitempty,base64"`
-	Metadata       map[string]string                       `json:"metadata,omitempty" validate:"omitempty"`
-	InstancesCount int                                     `json:"instances_count,omitempty" validate:"omitempty,min=1"`
+	Flavor     string                                  `json:"flavor" validate:"required,min=1"`
+	Name       string                                  `json:"name" validate:"required,min=3,max=63"`
+	ImageID    string                                  `json:"image_id" validate:"required,uuid4"`
+	Interfaces []instances.InterfaceInstanceCreateOpts `json:"interfaces" validate:"required,dive"`
+	Volumes    []instances.CreateVolumeOpts            `json:"volumes,omitempty" validate:"omitempty,required,dive"`
+	// Deprecated: use per-interface SecurityGroups on InterfaceInstanceCreateOpts instead.
+	// The top-level field cannot be combined with per-interface security groups; if omitted
+	// everywhere, the project's default security group is applied.
+	SecurityGroups []gcorecloud.ItemID `json:"security_groups,omitempty" validate:"omitempty,dive,uuid4"`
+	Keypair        string              `json:"keypair_name,omitempty"`
+	Password       string              `json:"password" validate:"omitempty,required_with=Username"`
+	Username       string              `json:"username" validate:"omitempty,required_with=Password"`
+	UserData       string              `json:"user_data,omitempty" validate:"omitempty,base64"`
+	Metadata       map[string]string   `json:"metadata,omitempty" validate:"omitempty"`
+	InstancesCount int                 `json:"instances_count,omitempty" validate:"omitempty,min=1"`
 }
 
 // Validate

--- a/gcore/gpu/v3/clusters/requests.go
+++ b/gcore/gpu/v3/clusters/requests.go
@@ -122,7 +122,7 @@ type ServerSettingsOpts struct {
 	// Deprecated: use per-interface SecurityGroups on the InterfaceOpts instead.
 	// The cluster-wide field cannot be combined with per-interface security groups.
 	// If omitted everywhere, the project's default security group is applied.
-	SecurityGroups []gcorecloud.ItemID    `json:"security_groups" validate:"omitempty,dive,uuid4"`
+	SecurityGroups []gcorecloud.ItemID    `json:"security_groups,omitempty" validate:"omitempty,dive,uuid4"`
 	Volumes        []VolumeOpts           `json:"volumes"`
 	UserData       *string                `json:"user_data,omitempty"`
 	Credentials    *ServerCredentialsOpts `json:"credentials,omitempty"`
@@ -133,7 +133,7 @@ type BaremetalServerSettingsOpts struct {
 	// Deprecated: use per-interface SecurityGroups on the InterfaceOpts instead.
 	// The cluster-wide field cannot be combined with per-interface security groups.
 	// If omitted everywhere, the project's default security group is applied.
-	SecurityGroups []gcorecloud.ItemID    `json:"security_groups" validate:"omitempty,dive,uuid4"`
+	SecurityGroups []gcorecloud.ItemID    `json:"security_groups,omitempty" validate:"omitempty,dive,uuid4"`
 	UserData       *string                `json:"user_data,omitempty"`
 	Credentials    *ServerCredentialsOpts `json:"credentials,omitempty"`
 }
@@ -165,8 +165,11 @@ type ExternalInterfaceOpts struct {
 	IPFamily            IPFamilyType `json:"ip_family,omitempty"`
 	PortSecurityEnabled *bool        `json:"port_security_enabled,omitempty"`
 	// SecurityGroups are the security group UUIDs applied to this interface.
-	// If omitted (or empty), the cluster-wide security_groups value applies;
-	// if both are omitted, the project's default security group is applied.
+	// Per-interface and cluster-wide security_groups are mutually exclusive: the
+	// API rejects a request that sets per-interface SGs while the cluster-wide
+	// security_groups list is also set. If this list is omitted (or empty), the
+	// cluster-wide security_groups applies to this interface; if both are
+	// omitted everywhere, the project's default security group is applied.
 	SecurityGroups []gcorecloud.ItemID `json:"security_groups,omitempty" validate:"omitempty,dive,uuid4"`
 }
 
@@ -182,8 +185,11 @@ type SubnetInterfaceOpts struct {
 	FloatingIP          *FloatingIPOpts `json:"floating_ip,omitempty"`
 	PortSecurityEnabled *bool           `json:"port_security_enabled,omitempty"`
 	// SecurityGroups are the security group UUIDs applied to this interface.
-	// If omitted (or empty), the cluster-wide security_groups value applies;
-	// if both are omitted, the project's default security group is applied.
+	// Per-interface and cluster-wide security_groups are mutually exclusive: the
+	// API rejects a request that sets per-interface SGs while the cluster-wide
+	// security_groups list is also set. If this list is omitted (or empty), the
+	// cluster-wide security_groups applies to this interface; if both are
+	// omitted everywhere, the project's default security group is applied.
 	SecurityGroups []gcorecloud.ItemID `json:"security_groups,omitempty" validate:"omitempty,dive,uuid4"`
 }
 
@@ -196,8 +202,11 @@ type AnySubnetInterfaceOpts struct {
 	FloatingIP          *FloatingIPOpts `json:"floating_ip,omitempty"`
 	PortSecurityEnabled *bool           `json:"port_security_enabled,omitempty"`
 	// SecurityGroups are the security group UUIDs applied to this interface.
-	// If omitted (or empty), the cluster-wide security_groups value applies;
-	// if both are omitted, the project's default security group is applied.
+	// Per-interface and cluster-wide security_groups are mutually exclusive: the
+	// API rejects a request that sets per-interface SGs while the cluster-wide
+	// security_groups list is also set. If this list is omitted (or empty), the
+	// cluster-wide security_groups applies to this interface; if both are
+	// omitted everywhere, the project's default security group is applied.
 	SecurityGroups []gcorecloud.ItemID `json:"security_groups,omitempty" validate:"omitempty,dive,uuid4"`
 }
 

--- a/gcore/gpu/v3/clusters/requests.go
+++ b/gcore/gpu/v3/clusters/requests.go
@@ -118,7 +118,10 @@ type ServerCredentialsOpts struct {
 }
 
 type ServerSettingsOpts struct {
-	Interfaces     []InterfaceOpts        `json:"interfaces"`
+	Interfaces []InterfaceOpts `json:"interfaces"`
+	// Deprecated: use per-interface SecurityGroups on the InterfaceOpts instead.
+	// The cluster-wide field cannot be combined with per-interface security groups.
+	// If omitted everywhere, the project's default security group is applied.
 	SecurityGroups []gcorecloud.ItemID    `json:"security_groups" validate:"omitempty,dive,uuid4"`
 	Volumes        []VolumeOpts           `json:"volumes"`
 	UserData       *string                `json:"user_data,omitempty"`
@@ -126,7 +129,10 @@ type ServerSettingsOpts struct {
 }
 
 type BaremetalServerSettingsOpts struct {
-	Interfaces     []InterfaceOpts        `json:"interfaces"`
+	Interfaces []InterfaceOpts `json:"interfaces"`
+	// Deprecated: use per-interface SecurityGroups on the InterfaceOpts instead.
+	// The cluster-wide field cannot be combined with per-interface security groups.
+	// If omitted everywhere, the project's default security group is applied.
 	SecurityGroups []gcorecloud.ItemID    `json:"security_groups" validate:"omitempty,dive,uuid4"`
 	UserData       *string                `json:"user_data,omitempty"`
 	Credentials    *ServerCredentialsOpts `json:"credentials,omitempty"`
@@ -158,6 +164,10 @@ type ExternalInterfaceOpts struct {
 	Type                string       `json:"type" validate:"required"`
 	IPFamily            IPFamilyType `json:"ip_family,omitempty"`
 	PortSecurityEnabled *bool        `json:"port_security_enabled,omitempty"`
+	// SecurityGroups are the security group UUIDs applied to this interface.
+	// If omitted (or empty), the cluster-wide security_groups value applies;
+	// if both are omitted, the project's default security group is applied.
+	SecurityGroups []gcorecloud.ItemID `json:"security_groups,omitempty" validate:"omitempty,dive,uuid4"`
 }
 
 type FloatingIPOpts struct {
@@ -171,6 +181,10 @@ type SubnetInterfaceOpts struct {
 	SubnetID            string          `json:"subnet_id" validate:"required"`
 	FloatingIP          *FloatingIPOpts `json:"floating_ip,omitempty"`
 	PortSecurityEnabled *bool           `json:"port_security_enabled,omitempty"`
+	// SecurityGroups are the security group UUIDs applied to this interface.
+	// If omitted (or empty), the cluster-wide security_groups value applies;
+	// if both are omitted, the project's default security group is applied.
+	SecurityGroups []gcorecloud.ItemID `json:"security_groups,omitempty" validate:"omitempty,dive,uuid4"`
 }
 
 type AnySubnetInterfaceOpts struct {
@@ -181,6 +195,10 @@ type AnySubnetInterfaceOpts struct {
 	IPAddress           *string         `json:"ip_address,omitempty"`
 	FloatingIP          *FloatingIPOpts `json:"floating_ip,omitempty"`
 	PortSecurityEnabled *bool           `json:"port_security_enabled,omitempty"`
+	// SecurityGroups are the security group UUIDs applied to this interface.
+	// If omitted (or empty), the cluster-wide security_groups value applies;
+	// if both are omitted, the project's default security group is applied.
+	SecurityGroups []gcorecloud.ItemID `json:"security_groups,omitempty" validate:"omitempty,dive,uuid4"`
 }
 
 // CreateClusterOpts allows extensions to add parameters to create cluster options.
@@ -408,12 +426,12 @@ type UpdatedServerCredentials struct {
 // UpdatedServerSettings represents the server settings to patch.
 type UpdatedServerSettings struct {
 	Credentials *UpdatedServerCredentials `json:"credentials,omitempty"`
-	UserData    *string                 `json:"user_data,omitempty"`
+	UserData    *string                   `json:"user_data,omitempty"`
 }
 
 // UpdateServersSettingsOpts specifies the parameters for the UpdateServersSettings method.
 type UpdateServersSettingsOpts struct {
-	ImageID         *string              `json:"image_id,omitempty" validate:"omitempty,uuid4"`
+	ImageID         *string                `json:"image_id,omitempty" validate:"omitempty,uuid4"`
 	ServersSettings *UpdatedServerSettings `json:"servers_settings,omitempty"`
 }
 

--- a/gcore/gpu/v3/clusters/results.go
+++ b/gcore/gpu/v3/clusters/results.go
@@ -34,6 +34,8 @@ type ExternalInterface struct {
 	Name     *string      `json:"name"`
 	Type     string       `json:"type"`
 	IPFamily IPFamilyType `json:"ip_family"`
+	// SecurityGroups are the resolved security groups applied to this interface.
+	SecurityGroups []gcorecloud.ItemIDName `json:"security_groups"`
 }
 
 type FloatingIP struct {
@@ -46,6 +48,8 @@ type SubnetInterface struct {
 	Type       string      `json:"type"`
 	SubnetID   string      `json:"subnet_id"`
 	FloatingIP *FloatingIP `json:"floating_ip"`
+	// SecurityGroups are the resolved security groups applied to this interface.
+	SecurityGroups []gcorecloud.ItemIDName `json:"security_groups"`
 }
 
 type AnySubnetInterface struct {
@@ -55,6 +59,8 @@ type AnySubnetInterface struct {
 	IPFamily   IPFamilyType `json:"ip_family"`
 	IPAddress  *string      `json:"ip_address"`
 	FloatingIP *FloatingIP  `json:"floating_ip"`
+	// SecurityGroups are the resolved security groups applied to this interface.
+	SecurityGroups []gcorecloud.ItemIDName `json:"security_groups"`
 }
 
 type InterfaceUnion struct {

--- a/gcore/instance/v1/instances/requests.go
+++ b/gcore/instance/v1/instances/requests.go
@@ -146,20 +146,23 @@ func (opts InterfaceInstanceCreateOpts) Validate() error {
 
 // CreateOpts represents options used to create a instance.
 type CreateOpts struct {
-	Flavor         string                        `json:"flavor" required:"true"`
-	Names          []string                      `json:"names,omitempty" validate:"required_without=NameTemplates"`
-	NameTemplates  []string                      `json:"name_templates,omitempty" validate:"required_without=Names"`
-	Volumes        []CreateVolumeOpts            `json:"volumes" validate:"dive"`
-	Interfaces     []InterfaceInstanceCreateOpts `json:"interfaces" required:"true" validate:"required,dive"`
-	SecurityGroups []gcorecloud.ItemID           `json:"security_groups,omitempty" validate:"omitempty,dive,uuid4"`
-	Keypair        string                        `json:"keypair_name,omitempty"`
-	Password       string                        `json:"password" validate:"omitempty,required_with=Username"`
-	Username       string                        `json:"username" validate:"omitempty,required_with=Password"`
-	UserData       string                        `json:"user_data" validate:"omitempty,base64"`
-	Metadata       *MetadataSetOpts              `json:"metadata,omitempty" validate:"omitempty,dive"`
-	Configuration  *MetadataSetOpts              `json:"configuration,omitempty" validate:"omitempty,dive"`
-	AllowAppPorts  bool                          `json:"allow_app_ports,omitempty"`
-	ServerGroupID  string                        `json:"servergroup_id,omitempty" validate:"omitempty,uuid4"`
+	Flavor        string                        `json:"flavor" required:"true"`
+	Names         []string                      `json:"names,omitempty" validate:"required_without=NameTemplates"`
+	NameTemplates []string                      `json:"name_templates,omitempty" validate:"required_without=Names"`
+	Volumes       []CreateVolumeOpts            `json:"volumes" validate:"dive"`
+	Interfaces    []InterfaceInstanceCreateOpts `json:"interfaces" required:"true" validate:"required,dive"`
+	// Deprecated: use per-interface SecurityGroups on InterfaceInstanceCreateOpts instead.
+	// The top-level field cannot be combined with per-interface security groups; if omitted
+	// everywhere, the project's default security group is applied.
+	SecurityGroups []gcorecloud.ItemID `json:"security_groups,omitempty" validate:"omitempty,dive,uuid4"`
+	Keypair        string              `json:"keypair_name,omitempty"`
+	Password       string              `json:"password" validate:"omitempty,required_with=Username"`
+	Username       string              `json:"username" validate:"omitempty,required_with=Password"`
+	UserData       string              `json:"user_data" validate:"omitempty,base64"`
+	Metadata       *MetadataSetOpts    `json:"metadata,omitempty" validate:"omitempty,dive"`
+	Configuration  *MetadataSetOpts    `json:"configuration,omitempty" validate:"omitempty,dive"`
+	AllowAppPorts  bool                `json:"allow_app_ports,omitempty"`
+	ServerGroupID  string              `json:"servergroup_id,omitempty" validate:"omitempty,uuid4"`
 }
 
 // Validate


### PR DESCRIPTION
## What

Adapts the Go SDK to the upstream cloud API change that introduces **per-interface `security_groups`** on instance/cluster interfaces and marks the **cluster-wide / top-level `security_groups`** field **deprecated**.

## Changes

**`gcore/gpu/v3/clusters`**
- Add `SecurityGroups []gcorecloud.ItemID` to interface **input** opts: `ExternalInterfaceOpts`, `SubnetInterfaceOpts`, `AnySubnetInterfaceOpts` (`security_groups`, `[{id}]`).
- Add `SecurityGroups []gcorecloud.ItemIDName` to interface **output** results: `ExternalInterface`, `SubnetInterface`, `AnySubnetInterface` (`[{id,name}]`, now returned by the API).
- Mark cluster-wide `ServerSettingsOpts.SecurityGroups` and `BaremetalServerSettingsOpts.SecurityGroups` as deprecated (doc comment).

**Deprecation annotations only** (no behavior change)
- `gcore/instance/v1/instances`: `CreateOpts.SecurityGroups` marked deprecated.
- `gcore/ai/v1/ais`: `CreateOpts.SecurityGroups` marked deprecated.

Per-interface support for regular instances already exists via the shared `instances.InterfaceInstanceCreateOpts`.

## Behavior

- Top-level cluster-wide `security_groups` cannot be combined with per-interface `security_groups`.
- If omitted everywhere, the project's default security group is applied (unchanged).

## Testing

- `go build` / `go vet` clean on touched packages (pre-existing fixture-compile failures in `file_share`/`loadbalancer` `testing` packages are unrelated and present on `master`).
- Validated against the terraform-provider-gcore companion PR (per-interface SG on `gcore_gpu_virtual_cluster`).
