### PR TITLE
MKAAS-1761 Add support for port_security_enabled on gpu cluster interfaces

### DIFF
--- a/gcore/gpu/v3/clusters/requests.go
+++ b/gcore/gpu/v3/clusters/requests.go
@@ -154,9 +154,10 @@ func (SubnetInterfaceOpts) implInterfaceOpts()    {}
 func (AnySubnetInterfaceOpts) implInterfaceOpts() {}
 
 type ExternalInterfaceOpts struct {
-	Name     *string      `json:"name,omitempty"`
-	Type     string       `json:"type" validate:"required"`
-	IPFamily IPFamilyType `json:"ip_family,omitempty"`
+	Name                *string      `json:"name,omitempty"`
+	Type                string       `json:"type" validate:"required"`
+	IPFamily            IPFamilyType `json:"ip_family,omitempty"`
+	PortSecurityEnabled *bool        `json:"port_security_enabled,omitempty"`
 }
 
 type FloatingIPOpts struct {
@@ -164,20 +165,22 @@ type FloatingIPOpts struct {
 }
 
 type SubnetInterfaceOpts struct {
-	NetworkID  string          `json:"network_id" validate:"required"`
-	Name       *string         `json:"name,omitempty"`
-	Type       string          `json:"type" validate:"required"`
-	SubnetID   string          `json:"subnet_id" validate:"required"`
-	FloatingIP *FloatingIPOpts `json:"floating_ip,omitempty"`
+	NetworkID           string          `json:"network_id" validate:"required"`
+	Name                *string         `json:"name,omitempty"`
+	Type                string          `json:"type" validate:"required"`
+	SubnetID            string          `json:"subnet_id" validate:"required"`
+	FloatingIP          *FloatingIPOpts `json:"floating_ip,omitempty"`
+	PortSecurityEnabled *bool           `json:"port_security_enabled,omitempty"`
 }
 
 type AnySubnetInterfaceOpts struct {
-	NetworkID  string          `json:"network_id" validate:"required"`
-	Name       *string         `json:"name,omitempty"`
-	Type       string          `json:"type" validate:"required"`
-	IPFamily   IPFamilyType    `json:"ip_family,omitempty"`
-	IPAddress  *string         `json:"ip_address,omitempty"`
-	FloatingIP *FloatingIPOpts `json:"floating_ip,omitempty"`
+	NetworkID           string          `json:"network_id" validate:"required"`
+	Name                *string         `json:"name,omitempty"`
+	Type                string          `json:"type" validate:"required"`
+	IPFamily            IPFamilyType    `json:"ip_family,omitempty"`
+	IPAddress           *string         `json:"ip_address,omitempty"`
+	FloatingIP          *FloatingIPOpts `json:"floating_ip,omitempty"`
+	PortSecurityEnabled *bool           `json:"port_security_enabled,omitempty"`
 }
 
 // CreateClusterOpts allows extensions to add parameters to create cluster options.


### PR DESCRIPTION
## Description

Added `port_security_enabled` to gpu cluster interface create requests.

https://gcore.com/docs/api-reference/cloud/gpu-bare-metal/create-bare-metal-gpu-cluster

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have followed the style guidelines of this project
- [x] I have tested my changes with the latest version of Go

## Further comments

I didn't add this field to responses, because API doesn't return it for some reason.